### PR TITLE
feat: improve team secrets handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ age = "0.10"
 # Secret detection
 regex = "1.10"
 
+# Text diffing
+similar = "2.6"
+
 # System signals
 libc = "0.2"
 tempfile = "3.8"

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -28,13 +28,10 @@ pub async fn init() -> Result<()> {
 
     Output::success("Identity created");
     println!();
-    println!("{}", "Your public key (share with team admins):".cyan());
+    println!("{}", "Your public key:".cyan());
     println!("{}", pubkey.green().bold());
     println!();
-    println!(
-        "{}",
-        "This key is also saved to ~/.tether/identity.pub".dimmed()
-    );
+    println!("{}", "Saved to ~/.tether/identity.pub".dimmed());
 
     Ok(())
 }

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -1,0 +1,95 @@
+use anyhow::Result;
+use owo_colors::OwoColorize;
+
+use crate::cli::output::Output;
+use crate::cli::prompts::Prompt;
+use crate::security::recipients;
+
+/// Initialize a new age identity
+pub async fn init() -> Result<()> {
+    if recipients::has_identity() {
+        Output::warning("Identity already exists");
+        println!("Run 'tether identity show' to see your public key");
+        println!("Run 'tether identity reset' to generate a new identity");
+        return Ok(());
+    }
+
+    Output::info("Generating age identity...");
+
+    let passphrase = Prompt::password_with_confirm(
+        "Enter passphrase to protect your identity:",
+        "Confirm passphrase:",
+    )?;
+
+    let identity = recipients::generate_identity();
+    recipients::store_identity(&identity, &passphrase)?;
+
+    let pubkey = recipients::get_public_key_from_identity(&identity);
+
+    Output::success("Identity created");
+    println!();
+    println!("{}", "Your public key (share with team admins):".cyan());
+    println!("{}", pubkey.green().bold());
+    println!();
+    println!(
+        "{}",
+        "This key is also saved to ~/.tether/identity.pub".dimmed()
+    );
+
+    Ok(())
+}
+
+/// Show public key
+pub async fn show() -> Result<()> {
+    let pubkey = recipients::get_public_key()?;
+    println!("{}", pubkey);
+    Ok(())
+}
+
+/// Unlock identity with passphrase
+pub async fn unlock() -> Result<()> {
+    if !recipients::has_identity() {
+        Output::error("No identity found. Run 'tether identity init' first.");
+        return Ok(());
+    }
+
+    if recipients::is_identity_unlocked() {
+        Output::info("Identity already unlocked");
+        return Ok(());
+    }
+
+    let passphrase = Prompt::password("Enter passphrase:")?;
+    recipients::load_identity(Some(&passphrase))?;
+
+    Output::success("Identity unlocked");
+    Ok(())
+}
+
+/// Lock identity (clear cache)
+pub async fn lock() -> Result<()> {
+    recipients::clear_cached_identity()?;
+    Output::success("Identity locked");
+    Ok(())
+}
+
+/// Reset identity (generate new)
+pub async fn reset() -> Result<()> {
+    if recipients::has_identity() {
+        let confirm = Prompt::confirm(
+            "This will delete your existing identity. You will lose access to any team secrets encrypted to your current key. Continue?",
+            false,
+        )?;
+        if !confirm {
+            Output::info("Aborted");
+            return Ok(());
+        }
+
+        // Clear existing
+        let home = home::home_dir().ok_or_else(|| anyhow::anyhow!("No home directory"))?;
+        let _ = std::fs::remove_file(home.join(".tether").join("identity.age"));
+        let _ = std::fs::remove_file(home.join(".tether").join("identity.pub"));
+        let _ = std::fs::remove_file(home.join(".tether").join("identity.cache"));
+    }
+
+    init().await
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -253,6 +253,11 @@ pub enum TeamAction {
         #[command(subcommand)]
         action: SecretsAction,
     },
+    /// Manage team files and sync preferences
+    Files {
+        #[command(subcommand)]
+        action: FilesAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -307,6 +312,42 @@ pub enum SecretsAction {
     Remove {
         /// Secret name
         name: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum FilesAction {
+    /// List synced team files
+    List,
+    /// Show local patterns (files never synced)
+    LocalPatterns,
+    /// Reset file to team version (clobber local changes)
+    Reset {
+        /// File to reset
+        file: Option<String>,
+        /// Reset all files
+        #[arg(long)]
+        all: bool,
+    },
+    /// Promote local file to team repository
+    Promote {
+        /// File to promote
+        file: String,
+    },
+    /// Mark file as personal (skip team sync)
+    Ignore {
+        /// File to ignore
+        file: String,
+    },
+    /// Unmark file as personal (resume team sync)
+    Unignore {
+        /// File to unignore
+        file: String,
+    },
+    /// Show diff between local and team version
+    Diff {
+        /// File to diff (all if not specified)
+        file: Option<String>,
     },
 }
 
@@ -379,6 +420,17 @@ impl Cli {
                     SecretsAction::Get { name } => team::secrets_get(name).await,
                     SecretsAction::List => team::secrets_list().await,
                     SecretsAction::Remove { name } => team::secrets_remove(name).await,
+                },
+                TeamAction::Files { action } => match action {
+                    FilesAction::List => team::files_list().await,
+                    FilesAction::LocalPatterns => team::files_local_patterns().await,
+                    FilesAction::Reset { file, all } => {
+                        team::files_reset(file.as_deref(), *all).await
+                    }
+                    FilesAction::Promote { file } => team::files_promote(file).await,
+                    FilesAction::Ignore { file } => team::files_ignore(file).await,
+                    FilesAction::Unignore { file } => team::files_unignore(file).await,
+                    FilesAction::Diff { file } => team::files_diff(file.as_deref()).await,
                 },
             },
             Commands::Resolve { file } => resolve::run(file.as_deref()).await,

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -378,6 +378,12 @@ pub enum ProjectsAction {
         #[arg(long)]
         project: Option<String>,
     },
+    /// Remove personal project secrets that are now team-owned
+    PurgePersonal {
+        /// Also purge from git history
+        #[arg(long)]
+        history: bool,
+    },
 }
 
 impl Cli {
@@ -469,6 +475,9 @@ impl Cli {
                     ProjectsAction::List => team::projects_list().await,
                     ProjectsAction::Remove { file, project } => {
                         team::projects_remove(file, project.as_deref()).await
+                    }
+                    ProjectsAction::PurgePersonal { history } => {
+                        team::projects_purge_personal(*history).await
                     }
                 },
             },

--- a/src/cli/commands/team.rs
+++ b/src/cli/commands/team.rs
@@ -524,10 +524,7 @@ pub async fn add(url: &str, name: Option<&str>, _no_auto_inject: bool) -> Result
         Output::info("As a team admin/contributor, you can push updates to team configs.");
         println!();
 
-        !Prompt::confirm(
-            "Enable write access? (No = read-only mode for regular team members)",
-            true,
-        )?
+        !Prompt::confirm("Enable write access? (No = read-only mode)", true)?
     } else {
         println!();
         Output::info("Read-only access detected (regular team member mode)");

--- a/src/cli/commands/team.rs
+++ b/src/cli/commands/team.rs
@@ -34,7 +34,7 @@ async fn prompt_for_team_repo() -> Result<String> {
         GitHubCli::is_installed() && GitHubCli::is_authenticated().await.unwrap_or(false);
 
     if gh_available {
-        let options = vec!["Create new GitHub repo", "Use existing repo URL"];
+        let options = vec!["Create new private GitHub repo", "Use existing repo URL"];
         let choice = Prompt::select("Team repository:", options, 0)?;
 
         if choice == 0 {
@@ -69,7 +69,10 @@ async fn prompt_for_team_repo() -> Result<String> {
             } else {
                 GitHubCli::create_org_repo(&owner, &repo_name, true).await?
             };
-            Progress::finish_success(&spinner, &format!("Created {}/{}", owner, repo_name));
+            Progress::finish_success(
+                &spinner,
+                &format!("Created {}/{} (private)", owner, repo_name),
+            );
 
             Ok(url)
         } else {

--- a/src/cli/prompts.rs
+++ b/src/cli/prompts.rs
@@ -59,4 +59,11 @@ impl Prompt {
             .without_confirmation()
             .prompt()?)
     }
+
+    pub fn password_with_confirm(message: &str, confirm_message: &str) -> Result<String> {
+        Ok(Password::new(message)
+            .with_display_mode(PasswordDisplayMode::Masked)
+            .with_custom_confirmation_message(confirm_message)
+            .prompt()?)
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -318,6 +318,9 @@ pub struct TeamsConfig {
     pub active: Option<String>,
     /// Map of team name -> team configuration
     pub teams: HashMap<String, TeamConfig>,
+    /// Allowed GitHub organizations for team repos (empty = no restriction)
+    #[serde(default)]
+    pub allowed_orgs: Vec<String>,
 }
 
 /// Project-local config syncing.

--- a/src/config.rs
+++ b/src/config.rs
@@ -302,6 +302,10 @@ pub struct TeamConfig {
     pub url: String,
     pub auto_inject: bool,
     pub read_only: bool,
+    /// Organizations that map to this team (full format: "github.com/org-name")
+    /// Projects belonging to these orgs will use team secrets instead of personal sync
+    #[serde(default)]
+    pub orgs: Vec<String>,
 }
 
 /// Multi-team sync configuration.
@@ -408,9 +412,13 @@ impl Default for ProjectConfigSettings {
             enabled: false,
             search_paths: vec!["~/Projects".to_string(), "~/Code".to_string()],
             patterns: vec![
-                ".env.local".to_string(),
-                "appsettings.*.json".to_string(),
+                ".env*".to_string(),              // .env, .env.local, .env.development, etc.
+                ".dev.vars".to_string(),          // Cloudflare Workers
+                "appsettings.*.json".to_string(), // .NET
                 ".vscode/settings.json".to_string(),
+                ".idea/**".to_string(),               // JetBrains
+                "*.xcconfig".to_string(),             // Xcode
+                "*service-account*.json".to_string(), // GCP
             ],
             only_if_gitignored: true,
         }

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,10 +1,16 @@
 pub mod encryption;
 pub mod keychain;
+pub mod recipients;
 pub mod secrets;
 
 pub use encryption::{decrypt_file, encrypt_file, generate_key};
 pub use keychain::{
     clear_cached_key, get_encryption_key, has_encryption_key, is_unlocked,
     store_encryption_key_with_passphrase, unlock_with_passphrase,
+};
+pub use recipients::{
+    clear_cached_identity, decrypt_with_identity, encrypt_to_recipients, generate_identity,
+    get_public_key, get_public_key_from_identity, has_identity, is_identity_unlocked,
+    load_identity, load_recipients, store_identity, validate_pubkey,
 };
 pub use secrets::{scan_for_secrets, SecretFinding, SecretType};

--- a/src/security/recipients.rs
+++ b/src/security/recipients.rs
@@ -211,7 +211,10 @@ pub fn load_recipients(recipients_dir: &Path) -> Result<Vec<age::x25519::Recipie
 }
 
 /// Encrypt data to multiple recipients
-pub fn encrypt_to_recipients(data: &[u8], recipients: &[age::x25519::Recipient]) -> Result<Vec<u8>> {
+pub fn encrypt_to_recipients(
+    data: &[u8],
+    recipients: &[age::x25519::Recipient],
+) -> Result<Vec<u8>> {
     if recipients.is_empty() {
         return Err(anyhow::anyhow!("No recipients specified"));
     }

--- a/src/security/recipients.rs
+++ b/src/security/recipients.rs
@@ -1,0 +1,323 @@
+use age::secrecy::{ExposeSecret, Secret};
+use anyhow::{Context, Result};
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+
+const IDENTITY_FILENAME: &str = "identity.age";
+const PUBKEY_FILENAME: &str = "identity.pub";
+
+/// Get path to user's encrypted identity file
+fn identity_path() -> Result<PathBuf> {
+    let home = home::home_dir().context("Could not find home directory")?;
+    Ok(home.join(".tether").join(IDENTITY_FILENAME))
+}
+
+/// Get path to user's public key file
+fn pubkey_path() -> Result<PathBuf> {
+    let home = home::home_dir().context("Could not find home directory")?;
+    Ok(home.join(".tether").join(PUBKEY_FILENAME))
+}
+
+/// Get path to cached decrypted identity (local only)
+fn cached_identity_path() -> Result<PathBuf> {
+    let home = home::home_dir().context("Could not find home directory")?;
+    Ok(home.join(".tether").join("identity.cache"))
+}
+
+/// Generate a new age X25519 identity
+pub fn generate_identity() -> age::x25519::Identity {
+    age::x25519::Identity::generate()
+}
+
+/// Get public key string from identity
+pub fn get_public_key_from_identity(identity: &age::x25519::Identity) -> String {
+    identity.to_public().to_string()
+}
+
+/// Store identity encrypted with passphrase
+pub fn store_identity(identity: &age::x25519::Identity, passphrase: &str) -> Result<()> {
+    let identity_str = identity.to_string();
+    let encryptor = age::Encryptor::with_user_passphrase(Secret::new(passphrase.to_owned()));
+
+    let mut encrypted = vec![];
+    let mut writer = encryptor
+        .wrap_output(&mut encrypted)
+        .map_err(|e| anyhow::anyhow!("Failed to create encryptor: {}", e))?;
+    writer.write_all(identity_str.expose_secret().as_bytes())?;
+    writer
+        .finish()
+        .map_err(|e| anyhow::anyhow!("Failed to finish encryption: {}", e))?;
+
+    let path = identity_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    #[cfg(unix)]
+    {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)?;
+        file.write_all(&encrypted)?;
+    }
+    #[cfg(not(unix))]
+    fs::write(&path, &encrypted)?;
+
+    // Also store public key for easy sharing
+    let pubkey = identity.to_public().to_string();
+    let pubkey_file = pubkey_path()?;
+    fs::write(&pubkey_file, &pubkey)?;
+
+    Ok(())
+}
+
+/// Load identity from cache or decrypt with passphrase
+pub fn load_identity(passphrase: Option<&str>) -> Result<age::x25519::Identity> {
+    // Try cache first
+    let cache_path = cached_identity_path()?;
+    if cache_path.exists() {
+        let identity_str = fs::read_to_string(&cache_path)?;
+        return identity_str
+            .parse()
+            .map_err(|e| anyhow::anyhow!("Invalid cached identity: {}", e));
+    }
+
+    // Need passphrase to decrypt
+    let passphrase = passphrase.ok_or_else(|| {
+        anyhow::anyhow!("Identity not cached. Provide passphrase or run 'tether identity unlock'")
+    })?;
+
+    let path = identity_path()?;
+    if !path.exists() {
+        return Err(anyhow::anyhow!(
+            "No identity found. Run 'tether identity init' first."
+        ));
+    }
+
+    let encrypted = fs::read(&path)?;
+    let decryptor = match age::Decryptor::new(&encrypted[..])
+        .map_err(|e| anyhow::anyhow!("Failed to create decryptor: {}", e))?
+    {
+        age::Decryptor::Passphrase(d) => d,
+        _ => return Err(anyhow::anyhow!("Identity not encrypted with passphrase")),
+    };
+
+    let mut identity_str = String::new();
+    let mut reader = decryptor
+        .decrypt(&Secret::new(passphrase.to_owned()), None)
+        .map_err(|_| anyhow::anyhow!("Wrong passphrase"))?;
+    reader.read_to_string(&mut identity_str)?;
+
+    let identity: age::x25519::Identity = identity_str
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Invalid identity: {}", e))?;
+
+    // Cache for future use
+    cache_identity(&identity)?;
+
+    Ok(identity)
+}
+
+/// Cache decrypted identity locally
+fn cache_identity(identity: &age::x25519::Identity) -> Result<()> {
+    let path = cached_identity_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let identity_str = identity.to_string();
+
+    #[cfg(unix)]
+    {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)?;
+        file.write_all(identity_str.expose_secret().as_bytes())?;
+    }
+    #[cfg(not(unix))]
+    fs::write(&path, identity_str.expose_secret())?;
+
+    Ok(())
+}
+
+/// Clear cached identity
+pub fn clear_cached_identity() -> Result<()> {
+    let path = cached_identity_path()?;
+    if path.exists() {
+        fs::remove_file(&path)?;
+    }
+    Ok(())
+}
+
+/// Check if identity exists
+pub fn has_identity() -> bool {
+    identity_path().map(|p| p.exists()).unwrap_or(false)
+}
+
+/// Check if identity is cached (unlocked)
+pub fn is_identity_unlocked() -> bool {
+    cached_identity_path().map(|p| p.exists()).unwrap_or(false)
+}
+
+/// Get user's public key string
+pub fn get_public_key() -> Result<String> {
+    let path = pubkey_path()?;
+    if path.exists() {
+        return fs::read_to_string(&path).context("Failed to read public key");
+    }
+
+    // Try to derive from cached identity
+    if let Ok(identity) = load_identity(None) {
+        return Ok(identity.to_public().to_string());
+    }
+
+    Err(anyhow::anyhow!(
+        "No public key found. Run 'tether identity init' or 'tether identity unlock'"
+    ))
+}
+
+/// Load recipients from a team's recipients directory
+pub fn load_recipients(recipients_dir: &Path) -> Result<Vec<age::x25519::Recipient>> {
+    let mut recipients = Vec::new();
+
+    if !recipients_dir.exists() {
+        return Ok(recipients);
+    }
+
+    for entry in fs::read_dir(recipients_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "pub") {
+            let pubkey = fs::read_to_string(&path)?;
+            let recipient: age::x25519::Recipient = pubkey
+                .trim()
+                .parse()
+                .map_err(|_| anyhow::anyhow!("Invalid public key in {:?}", path))?;
+            recipients.push(recipient);
+        }
+    }
+
+    Ok(recipients)
+}
+
+/// Encrypt data to multiple recipients
+pub fn encrypt_to_recipients(data: &[u8], recipients: &[age::x25519::Recipient]) -> Result<Vec<u8>> {
+    if recipients.is_empty() {
+        return Err(anyhow::anyhow!("No recipients specified"));
+    }
+
+    let recipients_boxed: Vec<Box<dyn age::Recipient + Send>> = recipients
+        .iter()
+        .map(|r| Box::new(r.clone()) as Box<dyn age::Recipient + Send>)
+        .collect();
+
+    let encryptor = age::Encryptor::with_recipients(recipients_boxed)
+        .ok_or_else(|| anyhow::anyhow!("Failed to create encryptor: no recipients"))?;
+
+    let mut encrypted = vec![];
+    let mut writer = encryptor
+        .wrap_output(&mut encrypted)
+        .map_err(|e| anyhow::anyhow!("Failed to wrap output: {}", e))?;
+    writer.write_all(data)?;
+    writer
+        .finish()
+        .map_err(|e| anyhow::anyhow!("Failed to finish encryption: {}", e))?;
+
+    Ok(encrypted)
+}
+
+/// Decrypt data with user's identity
+pub fn decrypt_with_identity(data: &[u8], identity: &age::x25519::Identity) -> Result<Vec<u8>> {
+    let decryptor = match age::Decryptor::new(data)
+        .map_err(|e| anyhow::anyhow!("Failed to create decryptor: {}", e))?
+    {
+        age::Decryptor::Recipients(d) => d,
+        _ => return Err(anyhow::anyhow!("Data not encrypted with recipients")),
+    };
+
+    let mut decrypted = vec![];
+    let mut reader = decryptor
+        .decrypt(std::iter::once(identity as &dyn age::Identity))
+        .map_err(|_| anyhow::anyhow!("Failed to decrypt - you may not be a recipient"))?;
+    reader.read_to_end(&mut decrypted)?;
+
+    Ok(decrypted)
+}
+
+/// Validate an age public key string
+pub fn validate_pubkey(pubkey: &str) -> Result<age::x25519::Recipient> {
+    pubkey
+        .trim()
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Invalid age public key format"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_and_encrypt_decrypt() {
+        let identity = generate_identity();
+        let recipient = identity.to_public();
+        let data = b"secret team data";
+
+        let encrypted = encrypt_to_recipients(data, &[recipient]).unwrap();
+        let decrypted = decrypt_with_identity(&encrypted, &identity).unwrap();
+
+        assert_eq!(decrypted, data);
+    }
+
+    #[test]
+    fn test_multi_recipient() {
+        let identity1 = generate_identity();
+        let identity2 = generate_identity();
+        let recipients = vec![identity1.to_public(), identity2.to_public()];
+        let data = b"shared secret";
+
+        let encrypted = encrypt_to_recipients(data, &recipients).unwrap();
+
+        // Both can decrypt
+        let decrypted1 = decrypt_with_identity(&encrypted, &identity1).unwrap();
+        let decrypted2 = decrypt_with_identity(&encrypted, &identity2).unwrap();
+
+        assert_eq!(decrypted1, data);
+        assert_eq!(decrypted2, data);
+    }
+
+    #[test]
+    fn test_wrong_recipient_fails() {
+        let identity1 = generate_identity();
+        let identity2 = generate_identity();
+        let data = b"secret";
+
+        // Encrypt only to identity1
+        let encrypted = encrypt_to_recipients(data, &[identity1.to_public()]).unwrap();
+
+        // identity2 cannot decrypt
+        let result = decrypt_with_identity(&encrypted, &identity2);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_pubkey() {
+        let identity = generate_identity();
+        let pubkey_str = identity.to_public().to_string();
+
+        let result = validate_pubkey(&pubkey_str);
+        assert!(result.is_ok());
+
+        let invalid = validate_pubkey("not-a-valid-key");
+        assert!(invalid.is_err());
+    }
+}

--- a/src/sync/git.rs
+++ b/src/sync/git.rs
@@ -286,6 +286,20 @@ pub fn normalize_remote_url(url: &str) -> String {
     normalized
 }
 
+/// Extract the org portion from a normalized URL
+/// Examples:
+/// - github.com/acme-corp/repo -> github.com/acme-corp
+/// - gitlab.com/group/subgroup/repo -> gitlab.com/group (first level only)
+pub fn extract_org_from_normalized_url(normalized_url: &str) -> Option<String> {
+    let parts: Vec<&str> = normalized_url.split('/').collect();
+    if parts.len() >= 2 {
+        // host/org (e.g., github.com/acme-corp)
+        Some(format!("{}/{}", parts[0], parts[1]))
+    } else {
+        None
+    }
+}
+
 /// Check if a file is gitignored in its repository
 pub fn is_gitignored(file_path: &Path) -> Result<bool> {
     // Get the directory containing the file
@@ -448,6 +462,28 @@ mod tests {
             normalize_remote_url("git@gitlab.com:group/subgroup/repo.git"),
             "gitlab.com/group/subgroup/repo"
         );
+    }
+
+    #[test]
+    fn test_extract_org_github() {
+        assert_eq!(
+            extract_org_from_normalized_url("github.com/acme-corp/repo"),
+            Some("github.com/acme-corp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_org_gitlab() {
+        assert_eq!(
+            extract_org_from_normalized_url("gitlab.com/group/subgroup/repo"),
+            Some("gitlab.com/group".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_org_invalid() {
+        assert_eq!(extract_org_from_normalized_url("github.com"), None);
+        assert_eq!(extract_org_from_normalized_url(""), None);
     }
 
     // Skip directory tests

--- a/src/sync/git.rs
+++ b/src/sync/git.rs
@@ -293,8 +293,8 @@ pub fn normalize_remote_url(url: &str) -> String {
 pub fn extract_org_from_normalized_url(normalized_url: &str) -> Option<String> {
     let parts: Vec<&str> = normalized_url.split('/').collect();
     if parts.len() >= 2 {
-        // host/org (e.g., github.com/acme-corp)
-        Some(format!("{}/{}", parts[0], parts[1]))
+        // host/org (e.g., github.com/acme-corp), normalized to lowercase
+        Some(format!("{}/{}", parts[0], parts[1]).to_lowercase())
     } else {
         None
     }
@@ -484,6 +484,14 @@ mod tests {
     fn test_extract_org_invalid() {
         assert_eq!(extract_org_from_normalized_url("github.com"), None);
         assert_eq!(extract_org_from_normalized_url(""), None);
+    }
+
+    #[test]
+    fn test_extract_org_case_normalization() {
+        assert_eq!(
+            extract_org_from_normalized_url("GitHub.com/ACME-Corp/Repo"),
+            Some("github.com/acme-corp".to_string())
+        );
     }
 
     // Skip directory tests

--- a/src/sync/layers.rs
+++ b/src/sync/layers.rs
@@ -1,0 +1,271 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::sync::merge::{detect_file_type, merge_files, FileType};
+
+/// Get the layers directory (~/.tether/layers)
+pub fn layers_dir() -> Result<PathBuf> {
+    let home = home::home_dir().context("Could not find home directory")?;
+    Ok(home.join(".tether").join("layers"))
+}
+
+/// Get the personal layer directory
+pub fn personal_layer_dir() -> Result<PathBuf> {
+    Ok(layers_dir()?.join("personal"))
+}
+
+/// Get a team's layer directory
+pub fn team_layer_dir(team_name: &str) -> Result<PathBuf> {
+    Ok(layers_dir()?.join("teams").join(team_name))
+}
+
+/// Get the merged output directory
+pub fn merged_dir() -> Result<PathBuf> {
+    let home = home::home_dir().context("Could not find home directory")?;
+    Ok(home.join(".tether").join("merged"))
+}
+
+/// Initialize layer directories
+pub fn init_layers(team_name: &str) -> Result<()> {
+    fs::create_dir_all(personal_layer_dir()?)?;
+    fs::create_dir_all(team_layer_dir(team_name)?)?;
+    fs::create_dir_all(merged_dir()?)?;
+    Ok(())
+}
+
+/// Map team dotfile name to personal dotfile name
+/// e.g., "team.zshrc" -> ".zshrc", "team.gitconfig" -> ".gitconfig"
+pub fn map_team_to_personal_name(team_name: &str) -> String {
+    if let Some(stripped) = team_name.strip_prefix("team.") {
+        format!(".{}", stripped)
+    } else if team_name.starts_with('.') {
+        team_name.to_string()
+    } else {
+        format!(".{}", team_name)
+    }
+}
+
+/// Copy team dotfiles from repo to team layer
+/// Renames team.* files to .* (e.g., team.zshrc -> .zshrc)
+pub fn sync_team_to_layer(team_name: &str, team_repo_dotfiles: &Path) -> Result<Vec<String>> {
+    let team_layer = team_layer_dir(team_name)?;
+    fs::create_dir_all(&team_layer)?;
+
+    let mut synced_files = Vec::new();
+
+    if !team_repo_dotfiles.exists() {
+        return Ok(synced_files);
+    }
+
+    for entry in fs::read_dir(team_repo_dotfiles)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.is_file() {
+            if let Some(orig_name) = entry.file_name().to_str() {
+                // Map team.* to .*
+                let personal_name = map_team_to_personal_name(orig_name);
+                let dest = team_layer.join(&personal_name);
+                fs::copy(&path, &dest)?;
+                synced_files.push(personal_name);
+            }
+        }
+    }
+
+    Ok(synced_files)
+}
+
+/// Capture personal dotfile to personal layer (if not already captured)
+/// Returns true if captured, false if already exists
+pub fn capture_personal_to_layer(filename: &str) -> Result<bool> {
+    let home = home::home_dir().context("Could not find home directory")?;
+    let personal_file = home.join(filename);
+    let layer_file = personal_layer_dir()?.join(filename);
+
+    // Only capture if personal file exists and not yet in layer
+    if personal_file.exists() && !layer_file.exists() {
+        fs::create_dir_all(layer_file.parent().unwrap())?;
+        fs::copy(&personal_file, &layer_file)?;
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+/// Update personal layer from home directory (for ongoing sync)
+pub fn update_personal_layer(filename: &str) -> Result<()> {
+    let home = home::home_dir().context("Could not find home directory")?;
+    let personal_file = home.join(filename);
+    let layer_file = personal_layer_dir()?.join(filename);
+
+    if personal_file.exists() {
+        fs::create_dir_all(layer_file.parent().unwrap())?;
+        fs::copy(&personal_file, &layer_file)?;
+    }
+
+    Ok(())
+}
+
+/// Merge team and personal layers, write to merged directory
+/// Returns the merged file path
+pub fn merge_layers(team_name: &str, filename: &str) -> Result<PathBuf> {
+    let team_file = team_layer_dir(team_name)?.join(filename);
+    let personal_file = personal_layer_dir()?.join(filename);
+    let merged_file = merged_dir()?.join(filename);
+
+    fs::create_dir_all(merged_file.parent().unwrap())?;
+
+    let merged_content = if personal_file.exists() && team_file.exists() {
+        // Both exist - merge with personal winning
+        merge_files(&team_file, &personal_file)?
+    } else if personal_file.exists() {
+        // Only personal - use as-is
+        fs::read_to_string(&personal_file)?
+    } else if team_file.exists() {
+        // Only team - use as-is
+        fs::read_to_string(&team_file)?
+    } else {
+        return Err(anyhow::anyhow!("Neither team nor personal file exists for {}", filename));
+    };
+
+    fs::write(&merged_file, &merged_content)?;
+    Ok(merged_file)
+}
+
+/// Apply merged file to home directory
+pub fn apply_merged_to_home(filename: &str) -> Result<()> {
+    let home = home::home_dir().context("Could not find home directory")?;
+    let merged_file = merged_dir()?.join(filename);
+    let home_file = home.join(filename);
+
+    if merged_file.exists() {
+        // Backup existing file if different
+        if home_file.exists() {
+            let home_content = fs::read_to_string(&home_file)?;
+            let merged_content = fs::read_to_string(&merged_file)?;
+            if home_content != merged_content {
+                // Create backup directory and backup the file
+                let backup_dir = crate::sync::create_backup_dir()?;
+                crate::sync::backup_file(&backup_dir, "dotfiles", filename, &home_file)?;
+            }
+        }
+
+        fs::copy(&merged_file, &home_file)?;
+    }
+
+    Ok(())
+}
+
+/// Full layer sync for a team dotfile:
+/// 1. Capture personal to layer (first time)
+/// 2. Merge team + personal
+/// 3. Apply to home
+pub fn sync_dotfile_with_layers(team_name: &str, filename: &str) -> Result<LayerSyncResult> {
+    let home = home::home_dir().context("Could not find home directory")?;
+    let team_file = team_layer_dir(team_name)?.join(filename);
+    let personal_layer_file = personal_layer_dir()?.join(filename);
+    let home_file = home.join(filename);
+
+    // Skip if team file doesn't exist
+    if !team_file.exists() {
+        return Ok(LayerSyncResult::Skipped);
+    }
+
+    let file_type = detect_file_type(Path::new(filename));
+    let had_personal = home_file.exists();
+
+    // Capture personal file to layer (first time only)
+    if had_personal && !personal_layer_file.exists() {
+        capture_personal_to_layer(filename)?;
+    }
+
+    // Merge and apply
+    merge_layers(team_name, filename)?;
+    apply_merged_to_home(filename)?;
+
+    if had_personal {
+        Ok(LayerSyncResult::Merged { file_type })
+    } else {
+        Ok(LayerSyncResult::TeamOnly)
+    }
+}
+
+/// Result of syncing a dotfile with layers
+#[derive(Debug)]
+pub enum LayerSyncResult {
+    /// Team and personal were merged
+    Merged { file_type: FileType },
+    /// Only team file existed
+    TeamOnly,
+    /// File was skipped (no team file)
+    Skipped,
+}
+
+/// Clean up layers for a team
+pub fn cleanup_team_layers(team_name: &str) -> Result<()> {
+    let team_layer = team_layer_dir(team_name)?;
+    if team_layer.exists() {
+        fs::remove_dir_all(&team_layer)?;
+    }
+    Ok(())
+}
+
+/// List files in team layer
+pub fn list_team_layer_files(team_name: &str) -> Result<Vec<String>> {
+    let team_layer = team_layer_dir(team_name)?;
+    let mut files = Vec::new();
+
+    if team_layer.exists() {
+        for entry in fs::read_dir(&team_layer)? {
+            let entry = entry?;
+            if entry.path().is_file() {
+                if let Some(name) = entry.file_name().to_str() {
+                    files.push(name.to_string());
+                }
+            }
+        }
+    }
+
+    Ok(files)
+}
+
+/// Re-merge all dotfiles for a team (after personal or team changes)
+pub fn remerge_all(team_name: &str) -> Result<Vec<String>> {
+    let team_layer = team_layer_dir(team_name)?;
+    let mut remerged = Vec::new();
+
+    if !team_layer.exists() {
+        return Ok(remerged);
+    }
+
+    for entry in fs::read_dir(&team_layer)? {
+        let entry = entry?;
+        if entry.path().is_file() {
+            if let Some(filename) = entry.file_name().to_str() {
+                merge_layers(team_name, filename)?;
+                apply_merged_to_home(filename)?;
+                remerged.push(filename.to_string());
+            }
+        }
+    }
+
+    Ok(remerged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_layer_paths() {
+        let layers = layers_dir().unwrap();
+        assert!(layers.ends_with("layers"));
+
+        let personal = personal_layer_dir().unwrap();
+        assert!(personal.ends_with("personal"));
+
+        let team = team_layer_dir("acme").unwrap();
+        assert!(team.ends_with("acme"));
+    }
+}

--- a/src/sync/merge.rs
+++ b/src/sync/merge.rs
@@ -1,0 +1,303 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::Path;
+
+/// File types we can merge intelligently
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FileType {
+    Toml,
+    Json,
+    Ini,      // gitconfig, .ini, .cfg
+    Plain,    // Shell scripts, unknown files - concatenate
+}
+
+/// Detect file type from path
+pub fn detect_file_type(path: &Path) -> FileType {
+    let extension = path.extension().and_then(|e| e.to_str());
+    let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+
+    // Check extension first
+    match extension {
+        Some("toml") => return FileType::Toml,
+        Some("json") => return FileType::Json,
+        Some("ini") | Some("cfg") => return FileType::Ini,
+        _ => {}
+    }
+
+    // Check filename patterns
+    if filename == ".gitconfig"
+        || filename.ends_with("gitconfig")
+        || filename == ".gitignore_global"
+    {
+        return FileType::Ini;
+    }
+
+    FileType::Plain
+}
+
+/// Merge two files: team (base) + personal (overlay)
+/// Personal wins on key conflicts
+pub fn merge_files(team_path: &Path, personal_path: &Path) -> Result<String> {
+    let file_type = detect_file_type(personal_path);
+
+    let team_content = fs::read_to_string(team_path)
+        .with_context(|| format!("Failed to read team file: {}", team_path.display()))?;
+    let personal_content = fs::read_to_string(personal_path)
+        .with_context(|| format!("Failed to read personal file: {}", personal_path.display()))?;
+
+    match file_type {
+        FileType::Toml => merge_toml(&team_content, &personal_content),
+        FileType::Json => merge_json(&team_content, &personal_content),
+        FileType::Ini => merge_ini(&team_content, &personal_content),
+        FileType::Plain => Ok(merge_plain(&team_content, &personal_content)),
+    }
+}
+
+/// Deep merge TOML: personal keys override team keys
+fn merge_toml(team: &str, personal: &str) -> Result<String> {
+    let team_val: toml::Value = toml::from_str(team).context("Invalid team TOML")?;
+    let personal_val: toml::Value = toml::from_str(personal).context("Invalid personal TOML")?;
+
+    let merged = deep_merge_toml(team_val, personal_val);
+    toml::to_string_pretty(&merged).context("Failed to serialize merged TOML")
+}
+
+fn deep_merge_toml(base: toml::Value, overlay: toml::Value) -> toml::Value {
+    match (base, overlay) {
+        (toml::Value::Table(mut base_map), toml::Value::Table(overlay_map)) => {
+            for (key, overlay_val) in overlay_map {
+                match base_map.remove(&key) {
+                    Some(base_val) => {
+                        base_map.insert(key, deep_merge_toml(base_val, overlay_val));
+                    }
+                    None => {
+                        base_map.insert(key, overlay_val);
+                    }
+                }
+            }
+            toml::Value::Table(base_map)
+        }
+        // For non-tables: overlay (personal) always wins
+        (_, overlay) => overlay,
+    }
+}
+
+/// Deep merge JSON: personal keys override team keys
+fn merge_json(team: &str, personal: &str) -> Result<String> {
+    let team_val: serde_json::Value = serde_json::from_str(team).context("Invalid team JSON")?;
+    let personal_val: serde_json::Value =
+        serde_json::from_str(personal).context("Invalid personal JSON")?;
+
+    let merged = deep_merge_json(team_val, personal_val);
+    serde_json::to_string_pretty(&merged).context("Failed to serialize merged JSON")
+}
+
+fn deep_merge_json(base: serde_json::Value, overlay: serde_json::Value) -> serde_json::Value {
+    match (base, overlay) {
+        (serde_json::Value::Object(mut base_map), serde_json::Value::Object(overlay_map)) => {
+            for (key, overlay_val) in overlay_map {
+                match base_map.remove(&key) {
+                    Some(base_val) => {
+                        base_map.insert(key, deep_merge_json(base_val, overlay_val));
+                    }
+                    None => {
+                        base_map.insert(key, overlay_val);
+                    }
+                }
+            }
+            serde_json::Value::Object(base_map)
+        }
+        // For non-objects: overlay (personal) always wins
+        (_, overlay) => overlay,
+    }
+}
+
+/// Merge INI/gitconfig: section-level merge, personal sections win
+/// Format: [section] or [section "subsection"] followed by key = value
+fn merge_ini(team: &str, personal: &str) -> Result<String> {
+    let team_sections = parse_ini(team);
+    let personal_sections = parse_ini(personal);
+
+    let mut merged = team_sections;
+
+    // Personal sections override team sections (at section level, not key level for simplicity)
+    // For gitconfig, users typically want their entire section to override
+    for (section, entries) in personal_sections {
+        merged.insert(section, entries);
+    }
+
+    Ok(serialize_ini(&merged))
+}
+
+/// Parse INI-style content into sections
+fn parse_ini(content: &str) -> std::collections::HashMap<String, Vec<String>> {
+    let mut sections = std::collections::HashMap::new();
+    let mut current_section = String::new();
+    let mut current_entries = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            // Save previous section
+            if !current_section.is_empty() || !current_entries.is_empty() {
+                sections.insert(current_section.clone(), current_entries);
+            }
+            current_section = trimmed.to_string();
+            current_entries = Vec::new();
+        } else {
+            current_entries.push(line.to_string());
+        }
+    }
+
+    // Save last section
+    if !current_section.is_empty() || !current_entries.is_empty() {
+        sections.insert(current_section, current_entries);
+    }
+
+    sections
+}
+
+/// Serialize INI sections back to string
+fn serialize_ini(sections: &std::collections::HashMap<String, Vec<String>>) -> String {
+    let mut result = Vec::new();
+
+    // Handle entries before any section header (e.g., comments at top)
+    if let Some(entries) = sections.get("") {
+        for entry in entries {
+            result.push(entry.clone());
+        }
+    }
+
+    // Sort sections for consistent output
+    let mut section_names: Vec<_> = sections.keys().filter(|k| !k.is_empty()).collect();
+    section_names.sort();
+
+    for section in section_names {
+        if !result.is_empty() {
+            result.push(String::new()); // Blank line between sections
+        }
+        result.push(section.clone());
+        if let Some(entries) = sections.get(section) {
+            for entry in entries {
+                result.push(entry.clone());
+            }
+        }
+    }
+
+    result.join("\n")
+}
+
+/// Merge plain text files by concatenation
+/// Team content first, then personal content (personal overrides if both define same things)
+fn merge_plain(team: &str, personal: &str) -> String {
+    let separator = "\n# --- Personal config below (overrides team defaults) ---\n";
+    format!("{}{}{}", team.trim_end(), separator, personal)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_file_type() {
+        assert_eq!(
+            detect_file_type(Path::new("config.toml")),
+            FileType::Toml
+        );
+        assert_eq!(
+            detect_file_type(Path::new("settings.json")),
+            FileType::Json
+        );
+        assert_eq!(
+            detect_file_type(Path::new(".gitconfig")),
+            FileType::Ini
+        );
+        assert_eq!(
+            detect_file_type(Path::new(".zshrc")),
+            FileType::Plain
+        );
+    }
+
+    #[test]
+    fn test_merge_toml_deep() {
+        let team = r#"
+[build]
+jobs = 4
+
+[alias]
+t = "test"
+b = "build"
+"#;
+        let personal = r#"
+[build]
+jobs = 8
+target = "release"
+
+[alias]
+t = "test --release"
+"#;
+        let merged = merge_toml(team, personal).unwrap();
+
+        // personal values should win
+        assert!(merged.contains("jobs = 8"));
+        // personal additions
+        assert!(merged.contains("target = \"release\""));
+        // personal override
+        assert!(merged.contains("t = \"test --release\""));
+        // team value preserved if not in personal
+        assert!(merged.contains("b = \"build\""));
+    }
+
+    #[test]
+    fn test_merge_json_deep() {
+        let team = r#"{"a": 1, "b": {"x": 10, "y": 20}}"#;
+        let personal = r#"{"a": 2, "b": {"x": 15}, "c": 3}"#;
+        let merged = merge_json(team, personal).unwrap();
+
+        let val: serde_json::Value = serde_json::from_str(&merged).unwrap();
+        assert_eq!(val["a"], 2); // personal wins
+        assert_eq!(val["b"]["x"], 15); // personal wins
+        assert_eq!(val["b"]["y"], 20); // team preserved
+        assert_eq!(val["c"], 3); // personal addition
+    }
+
+    #[test]
+    fn test_merge_ini() {
+        let team = r#"
+[user]
+    name = Team Name
+    email = team@example.com
+
+[alias]
+    st = status
+"#;
+        let personal = r#"
+[user]
+    name = Personal Name
+
+[core]
+    editor = vim
+"#;
+        let merged = merge_ini(team, personal).unwrap();
+
+        // personal section replaces team section entirely
+        assert!(merged.contains("name = Personal Name"));
+        assert!(!merged.contains("email = team@example.com")); // Gone because [user] replaced
+        // team sections preserved if not in personal
+        assert!(merged.contains("st = status"));
+        // personal additions
+        assert!(merged.contains("editor = vim"));
+    }
+
+    #[test]
+    fn test_merge_plain() {
+        let team = "export TEAM_VAR=1";
+        let personal = "export PERSONAL_VAR=2";
+        let merged = merge_plain(team, personal);
+
+        assert!(merged.contains("TEAM_VAR=1"));
+        assert!(merged.contains("PERSONAL_VAR=2"));
+        assert!(merged.contains("# --- Personal config below"));
+    }
+}

--- a/src/sync/merge.rs
+++ b/src/sync/merge.rs
@@ -25,19 +25,27 @@ pub fn detect_file_type(path: &Path) -> FileType {
     }
 
     // GitConfig - uses [include] directive
-    if filename == ".gitconfig"
-        || filename.ends_with("gitconfig")
-        || filename == "team.gitconfig"
-    {
+    if filename == ".gitconfig" || filename.ends_with("gitconfig") || filename == "team.gitconfig" {
         return FileType::GitConfig;
     }
 
     // Shell files - use source directive
     // Be explicit to avoid matching .npmrc, .yarnrc, etc.
     let shell_files = [
-        ".zshrc", ".bashrc", ".bash_profile", ".profile", ".zprofile", ".zshenv",
-        ".bash_login", ".bash_logout", ".zlogin", ".zlogout",
-        "team.zshrc", "team.bashrc", "team.bash_profile", "team.profile",
+        ".zshrc",
+        ".bashrc",
+        ".bash_profile",
+        ".profile",
+        ".zprofile",
+        ".zshenv",
+        ".bash_login",
+        ".bash_logout",
+        ".zlogin",
+        ".zlogout",
+        "team.zshrc",
+        "team.bashrc",
+        "team.bash_profile",
+        "team.profile",
     ];
     if shell_files.contains(&filename) {
         return FileType::Shell;
@@ -60,12 +68,10 @@ pub fn merge_files(team_path: &Path, personal_path: &Path) -> Result<String> {
     match file_type {
         FileType::Toml => merge_toml(&team_content, &personal_content),
         FileType::Json => merge_json(&team_content, &personal_content),
-        FileType::Shell | FileType::GitConfig | FileType::Unknown => {
-            Err(anyhow::anyhow!(
-                "File type {:?} should use source/include, not merge",
-                file_type
-            ))
-        }
+        FileType::Shell | FileType::GitConfig | FileType::Unknown => Err(anyhow::anyhow!(
+            "File type {:?} should use source/include, not merge",
+            file_type
+        )),
     }
 }
 
@@ -139,8 +145,14 @@ mod tests {
         assert_eq!(detect_file_type(Path::new("settings.json")), FileType::Json);
 
         // Git config - use [include]
-        assert_eq!(detect_file_type(Path::new(".gitconfig")), FileType::GitConfig);
-        assert_eq!(detect_file_type(Path::new("team.gitconfig")), FileType::GitConfig);
+        assert_eq!(
+            detect_file_type(Path::new(".gitconfig")),
+            FileType::GitConfig
+        );
+        assert_eq!(
+            detect_file_type(Path::new("team.gitconfig")),
+            FileType::GitConfig
+        );
 
         // Shell files - use source
         assert_eq!(detect_file_type(Path::new(".zshrc")), FileType::Shell);
@@ -196,5 +208,4 @@ t = "test --release"
         assert_eq!(val["b"]["y"], 20); // team preserved
         assert_eq!(val["c"], 3); // personal addition
     }
-
 }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -19,7 +19,7 @@ pub use conflict::{
 };
 pub use discovery::discover_sourced_dirs;
 pub use engine::SyncEngine;
-pub use git::GitBackend;
+pub use git::{extract_org_from_normalized_url, GitBackend};
 pub use layers::{
     init_layers, list_team_layer_files, map_team_to_personal_name, merge_layers, remerge_all,
     sync_dotfile_with_layers, sync_team_to_layer, LayerSyncResult,
@@ -29,8 +29,8 @@ pub use packages::{import_packages, sync_packages};
 pub use state::{MachineState, SyncState};
 pub use team::{
     default_local_patterns, discover_symlinkable_dirs, extract_org_from_url,
-    extract_team_name_from_url, get_project_org, is_local_file, project_matches_team_orgs,
-    resolve_conflict, TeamManifest,
+    extract_team_name_from_url, find_team_for_project, get_project_org, glob_match, is_local_file,
+    project_matches_team_orgs, resolve_conflict, TeamManifest,
 };
 
 use anyhow::Result;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -26,7 +26,7 @@ pub use layers::{
 };
 pub use merge::{detect_file_type, merge_files, FileType};
 pub use packages::{import_packages, sync_packages};
-pub use state::{MachineState, SyncState};
+pub use state::{FileState, MachineState, SyncState};
 pub use team::{
     default_local_patterns, discover_symlinkable_dirs, extract_org_from_url,
     extract_team_name_from_url, find_team_for_project, get_project_org, glob_match, is_local_file,

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -3,6 +3,7 @@ pub mod conflict;
 pub mod discovery;
 pub mod engine;
 pub mod git;
+pub mod layers;
 pub mod merge;
 pub mod packages;
 pub mod state;
@@ -21,6 +22,10 @@ pub use engine::SyncEngine;
 pub use git::GitBackend;
 pub use packages::{import_packages, sync_packages};
 pub use state::{MachineState, SyncState};
+pub use layers::{
+    init_layers, list_team_layer_files, map_team_to_personal_name, merge_layers, remerge_all,
+    sync_dotfile_with_layers, sync_team_to_layer, LayerSyncResult,
+};
 pub use merge::{detect_file_type, merge_files, FileType};
 pub use team::{
     discover_symlinkable_dirs, extract_team_name_from_url, resolve_conflict, TeamManifest,

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -20,15 +20,17 @@ pub use conflict::{
 pub use discovery::discover_sourced_dirs;
 pub use engine::SyncEngine;
 pub use git::GitBackend;
-pub use packages::{import_packages, sync_packages};
-pub use state::{MachineState, SyncState};
 pub use layers::{
     init_layers, list_team_layer_files, map_team_to_personal_name, merge_layers, remerge_all,
     sync_dotfile_with_layers, sync_team_to_layer, LayerSyncResult,
 };
 pub use merge::{detect_file_type, merge_files, FileType};
+pub use packages::{import_packages, sync_packages};
+pub use state::{MachineState, SyncState};
 pub use team::{
-    discover_symlinkable_dirs, extract_team_name_from_url, resolve_conflict, TeamManifest,
+    default_local_patterns, discover_symlinkable_dirs, extract_org_from_url,
+    extract_team_name_from_url, get_project_org, is_local_file, project_matches_team_orgs,
+    resolve_conflict, TeamManifest,
 };
 
 use anyhow::Result;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -3,6 +3,7 @@ pub mod conflict;
 pub mod discovery;
 pub mod engine;
 pub mod git;
+pub mod merge;
 pub mod packages;
 pub mod state;
 pub mod team;
@@ -20,6 +21,7 @@ pub use engine::SyncEngine;
 pub use git::GitBackend;
 pub use packages::{import_packages, sync_packages};
 pub use state::{MachineState, SyncState};
+pub use merge::{detect_file_type, merge_files, FileType};
 pub use team::{
     discover_symlinkable_dirs, extract_team_name_from_url, resolve_conflict, TeamManifest,
 };


### PR DESCRIPTION
## Summary

- Add warning when team secrets skipped during sync (not a recipient)
- Auto-push on `projects_add` (no more manual sync required)
- Backup files before overwriting team project secrets
- Re-encrypt all secrets when recipients added/removed
- Normalize org case to lowercase for consistency
- Distinguish "not a recipient" from other decrypt errors
- Add test for case normalization

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (118 tests)
- [ ] Manual test: add recipient, verify re-encryption
- [ ] Manual test: sync with team secrets, verify skip warning