### PR TITLE
feat: explicit feature toggles and collab secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ website/node_modules/
 website/dist/
 website/.astro/
 website/bun.lockb
+*.bun-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-01-18
+
+### Added
+
+- **Collab secrets**: Share project secrets with GitHub collaborators (`tether collab init/join/add/refresh`)
+- **Feature toggles**: Granular control over sync features (`personal_dotfiles`, `personal_packages`, `team_dotfiles`, `collab_secrets`)
+- Package timestamps: Track when manifests were modified and packages upgraded (`tether status`)
+
+### Changed
+
+- Reduced config/state file reloading during sync operations
+
+### Security
+
+- Collab name validation to prevent path traversal attacks
+- Symlink validation in team repos to stay within repo bounds
+
 ## [1.2.0] - 2026-01-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tether"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 authors = ["Paddo Tech"]
 description = "Sync your development environment across machines automatically"

--- a/src/cli/commands/collab.rs
+++ b/src/cli/commands/collab.rs
@@ -4,24 +4,55 @@ use crate::github::GitHubCli;
 use crate::sync::git::{get_remote_url, normalize_remote_url};
 use crate::sync::GitBackend;
 use anyhow::Result;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-/// Metadata stored in .tether-collab.toml
+/// Check if collab feature is enabled, return early with message if not
+fn require_collab_feature() -> Result<Config> {
+    let config = Config::load()?;
+    if !config.features.collab_secrets {
+        Output::warning("Collab feature is not enabled");
+        Output::info("Enable with: tether config features enable collab_secrets");
+        anyhow::bail!("collab_secrets feature is disabled");
+    }
+    Ok(config)
+}
+
+/// Validate collab name is safe for path construction
+fn validate_collab_name(name: &str) -> Result<()> {
+    if name.is_empty()
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains("..")
+        || name.starts_with('.')
+    {
+        anyhow::bail!("Invalid collab name: {}", name);
+    }
+    Ok(())
+}
+
+/// Metadata stored in .tether-collab.toml (for reading)
 #[derive(Debug, Default, Deserialize)]
-#[allow(dead_code)] // Fields used for parsing, may be used in future versions
 struct CollabMetadata {
-    #[serde(default)]
-    version: u32,
-    #[serde(default)]
-    created_by: Option<String>,
     #[serde(default)]
     projects: Vec<String>,
     #[serde(default)]
     authorized: Vec<String>,
 }
 
+/// Metadata for writing .tether-collab.toml
+#[derive(Debug, Serialize)]
+struct CollabMetadataWrite<'a> {
+    version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    created_by: Option<&'a str>,
+    projects: &'a [String],
+    authorized: &'a [String],
+}
+
 /// Initialize a new collab for the current project
 pub async fn init(project_path: Option<&str>) -> Result<()> {
+    let mut config = require_collab_feature()?;
+
     // Determine project directory
     let project_dir = if let Some(path) = project_path {
         std::path::PathBuf::from(path)
@@ -42,7 +73,6 @@ pub async fn init(project_path: Option<&str>) -> Result<()> {
     println!();
 
     // Check if already has a collab
-    let config = Config::load()?;
     if config.collab_for_project(&normalized_url).is_some() {
         Output::warning("This project already has a collab configured");
         return Ok(());
@@ -77,6 +107,7 @@ pub async fn init(project_path: Option<&str>) -> Result<()> {
     // Create collab sync repo
     let default_repo_name = format!("{}-dotfiles", repo);
     let collab_repo_name = Prompt::input("Collab repo name", Some(&default_repo_name))?;
+    validate_collab_name(&collab_repo_name)?;
 
     let username = GitHubCli::get_username().await?;
     if GitHubCli::repo_exists(&username, &collab_repo_name).await? {
@@ -106,6 +137,9 @@ pub async fn init(project_path: Option<&str>) -> Result<()> {
         GitBackend::clone(&collab_url, &collab_dir)?;
     }
 
+    // Open git backend once for all subsequent operations
+    let git = GitBackend::open(&collab_dir)?;
+
     // Create recipients directory and add self
     let recipients_dir = collab_dir.join("recipients");
     std::fs::create_dir_all(&recipients_dir)?;
@@ -120,19 +154,20 @@ pub async fn init(project_path: Option<&str>) -> Result<()> {
     std::fs::create_dir_all(collab_dir.join("projects"))?;
 
     // Create .tether-collab.toml metadata
-    let metadata = format!(
-        r#"# Managed by tether - edit with caution
-version = 1
-created_by = "{}"
-projects = ["{}"]
-authorized = {:?}
-"#,
-        username, normalized_url, collaborators
+    let projects = vec![normalized_url.clone()];
+    let metadata = CollabMetadataWrite {
+        version: 1,
+        created_by: Some(&username),
+        projects: &projects,
+        authorized: &collaborators,
+    };
+    let metadata_content = format!(
+        "# Managed by tether - edit with caution\n{}",
+        toml::to_string_pretty(&metadata)?
     );
-    std::fs::write(collab_dir.join(".tether-collab.toml"), metadata)?;
+    std::fs::write(collab_dir.join(".tether-collab.toml"), metadata_content)?;
 
     // Commit and push
-    let git = GitBackend::open(&collab_dir)?;
     if git.has_changes()? {
         git.commit("Initialize collab", &username)?;
         git.push()?;
@@ -140,7 +175,6 @@ authorized = {:?}
     Progress::finish_success(&pb, "Collab repository ready");
 
     // Update config
-    let mut config = Config::load()?;
     let teams = config.teams.get_or_insert_with(Default::default);
     teams.collabs.insert(
         collab_name.clone(),
@@ -168,6 +202,8 @@ authorized = {:?}
 
 /// Join an existing collab
 pub async fn join(url: &str) -> Result<()> {
+    let mut config = require_collab_feature()?;
+
     Output::header("Join Collaboration");
     println!();
 
@@ -175,9 +211,9 @@ pub async fn join(url: &str) -> Result<()> {
     let (owner, repo) = GitHubCli::parse_repo_url(url)
         .ok_or_else(|| anyhow::anyhow!("Could not parse GitHub URL: {}", url))?;
     let collab_name = repo.clone();
+    validate_collab_name(&collab_name)?;
 
     // Check if already joined
-    let config = Config::load()?;
     if let Some(teams) = &config.teams {
         if teams.collabs.contains_key(&collab_name) {
             Output::warning("Already joined this collab");
@@ -185,13 +221,78 @@ pub async fn join(url: &str) -> Result<()> {
         }
     }
 
-    // Clone collab repo
+    // Clone collab repo (temporarily, to read metadata)
     let collab_dir = Config::collab_repo_dir(&collab_name)?;
     std::fs::create_dir_all(collab_dir.parent().unwrap())?;
 
     let pb = Progress::spinner("Cloning collab repository...");
     GitBackend::clone(url, &collab_dir)?;
     Progress::finish_success(&pb, "Repository cloned");
+
+    // Read metadata to get projects
+    let metadata_path = collab_dir.join(".tether-collab.toml");
+    let (projects, authorized) = if metadata_path.exists() {
+        let content = std::fs::read_to_string(&metadata_path)?;
+        match toml::from_str::<CollabMetadata>(&content) {
+            Ok(metadata) => (metadata.projects, metadata.authorized),
+            Err(e) => {
+                Output::warning(&format!("Malformed .tether-collab.toml: {}", e));
+                (Vec::new(), Vec::new())
+            }
+        }
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
+    // Verify user is a collaborator on ALL configured projects
+    let username = GitHubCli::get_username().await?;
+    if !projects.is_empty() {
+        Output::info("Verifying collaborator access...");
+        let mut not_collaborator_on: Vec<String> = Vec::new();
+
+        for project_url in &projects {
+            // Parse owner/repo from normalized URL (github.com/owner/repo)
+            let parts: Vec<&str> = project_url.split('/').collect();
+            if parts.len() >= 3 {
+                let project_owner = parts[1];
+                let project_repo = parts[2];
+
+                match GitHubCli::get_collaborators(project_owner, project_repo).await {
+                    Ok(collaborators) => {
+                        let is_collab = collaborators
+                            .iter()
+                            .any(|c| c.eq_ignore_ascii_case(&username));
+                        if !is_collab {
+                            not_collaborator_on.push(format!("{}/{}", project_owner, project_repo));
+                        }
+                    }
+                    Err(_) => {
+                        // Can't verify - might not have access to check collaborators
+                        Output::warning(&format!(
+                            "Could not verify access to {}/{}",
+                            project_owner, project_repo
+                        ));
+                    }
+                }
+            }
+        }
+
+        if !not_collaborator_on.is_empty() {
+            Output::error("You are not a collaborator on these projects:");
+            for project in &not_collaborator_on {
+                println!("  • {}", project);
+            }
+            // Clean up cloned repo
+            std::fs::remove_dir_all(&collab_dir).ok();
+            anyhow::bail!("Must be a GitHub collaborator on all projects to join this collab");
+        }
+    }
+
+    // Warn about permission drift if collab has authorized list
+    if !authorized.is_empty() && !authorized.iter().any(|a| a.eq_ignore_ascii_case(&username)) {
+        Output::warning("You're not in the collab's authorized list (permission drift)");
+        Output::info("Ask the owner to run 'tether collab refresh' to update the list");
+    }
 
     // Ensure user has identity
     let identity_pub = match crate::security::get_public_key() {
@@ -204,7 +305,6 @@ pub async fn join(url: &str) -> Result<()> {
     };
 
     // Add self as recipient
-    let username = GitHubCli::get_username().await?;
     let recipients_dir = collab_dir.join("recipients");
     std::fs::create_dir_all(&recipients_dir)?;
     let pub_file = recipients_dir.join(format!("{}.pub", username));
@@ -218,25 +318,14 @@ pub async fn join(url: &str) -> Result<()> {
         Output::success(&format!("Added {} as recipient", username));
     }
 
-    // Read metadata to get projects
-    let metadata_path = collab_dir.join(".tether-collab.toml");
-    let projects = if metadata_path.exists() {
-        let content = std::fs::read_to_string(&metadata_path)?;
-        let metadata: CollabMetadata = toml::from_str(&content).unwrap_or_default();
-        metadata.projects
-    } else {
-        Vec::new()
-    };
-
     // Update config
-    let mut config = Config::load()?;
     let teams = config.teams.get_or_insert_with(Default::default);
     teams.collabs.insert(
         collab_name.clone(),
         CollabConfig {
             sync_url: url.to_string(),
             projects,
-            members_cache: vec![owner, username],
+            members_cache: vec![owner, username.clone()],
             last_refresh: Some(chrono::Utc::now()),
             enabled: true,
         },
@@ -253,6 +342,8 @@ pub async fn join(url: &str) -> Result<()> {
 
 /// Add a secret file to the collab
 pub async fn add(file: &str, project_path: Option<&str>) -> Result<()> {
+    let config = require_collab_feature()?;
+
     // Determine project directory
     let project_dir = if let Some(path) = project_path {
         std::path::PathBuf::from(path)
@@ -265,7 +356,6 @@ pub async fn add(file: &str, project_path: Option<&str>) -> Result<()> {
     let normalized_url = normalize_remote_url(&remote_url);
 
     // Find collab for this project
-    let config = Config::load()?;
     let (collab_name, _collab_config) =
         config.collab_for_project(&normalized_url).ok_or_else(|| {
             anyhow::anyhow!(
@@ -298,30 +388,46 @@ pub async fn add(file: &str, project_path: Option<&str>) -> Result<()> {
     if !file_path.exists() {
         return Err(anyhow::anyhow!("File not found: {}", file_path.display()));
     }
+
+    // Security: prevent path traversal attacks
+    let canonical_project = project_dir.canonicalize()?;
+    let canonical_file = file_path.canonicalize()?;
+    if !canonical_file.starts_with(&canonical_project) {
+        return Err(anyhow::anyhow!(
+            "Path traversal not allowed: file must be within project directory"
+        ));
+    }
+
+    // Use sanitized relative path for destination
+    let relative_path = canonical_file
+        .strip_prefix(&canonical_project)
+        .map_err(|_| anyhow::anyhow!("Failed to compute relative path"))?;
+
     let content = std::fs::read(&file_path)?;
 
     // Encrypt to all recipients
     let encrypted = crate::security::encrypt_to_recipients(&content, &recipients)?;
 
-    // Write to collab repo
+    // Write to collab repo (using sanitized relative path)
     let dest_dir = collab_dir.join("projects").join(&normalized_url);
     std::fs::create_dir_all(&dest_dir)?;
-    let dest_file = dest_dir.join(format!("{}.age", file));
+    let dest_file = dest_dir.join(format!("{}.age", relative_path.display()));
     std::fs::write(&dest_file, encrypted)?;
 
     // Commit and push
+    let relative_path_str = relative_path.display().to_string();
     if git.has_changes()? {
         let username = GitHubCli::get_username()
             .await
             .unwrap_or_else(|_| "unknown".to_string());
         git.commit(
-            &format!("Add secret: {}/{}", normalized_url, file),
+            &format!("Add secret: {}/{}", normalized_url, relative_path_str),
             &username,
         )?;
         git.push()?;
     }
 
-    Output::success(&format!("Added {} to collab", file));
+    Output::success(&format!("Added {} to collab", relative_path_str));
     Output::info(&format!("Encrypted to {} recipient(s)", recipients.len()));
 
     Ok(())
@@ -329,6 +435,8 @@ pub async fn add(file: &str, project_path: Option<&str>) -> Result<()> {
 
 /// Refresh collaborators from GitHub and re-encrypt secrets
 pub async fn refresh(project_path: Option<&str>) -> Result<()> {
+    let mut config = require_collab_feature()?;
+
     // Determine project directory
     let project_dir = if let Some(path) = project_path {
         std::path::PathBuf::from(path)
@@ -339,13 +447,11 @@ pub async fn refresh(project_path: Option<&str>) -> Result<()> {
     // Get project's git remote
     let remote_url = get_remote_url(&project_dir)?;
     let normalized_url = normalize_remote_url(&remote_url);
-
-    // Find collab for this project
-    let mut config = Config::load()?;
-    let (collab_name, _) = config
+    let (collab_name, collab_config) = config
         .collab_for_project(&normalized_url)
         .ok_or_else(|| anyhow::anyhow!("No collab configured for this project"))?;
     let collab_name = collab_name.clone();
+    let all_projects = collab_config.projects.clone();
 
     let collab_dir = Config::collab_repo_dir(&collab_name)?;
     if !collab_dir.exists() {
@@ -359,12 +465,40 @@ pub async fn refresh(project_path: Option<&str>) -> Result<()> {
     Output::header("Refresh Collaborators");
     println!();
 
-    // Fetch current collaborators
+    // Fetch current collaborators for ALL projects
     let pb = Progress::spinner("Fetching collaborators from GitHub...");
+    let mut all_collaborators: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    // Start with current project
     let collaborators = GitHubCli::get_collaborators(&owner, &repo).await?;
+    for c in &collaborators {
+        all_collaborators.insert(c.to_lowercase());
+    }
+
+    // Check all other projects in this collab
+    for project_url in &all_projects {
+        let parts: Vec<&str> = project_url.split('/').collect();
+        if parts.len() >= 3 {
+            let project_owner = parts[1];
+            let project_repo = parts[2];
+            if let Ok(project_collabs) =
+                GitHubCli::get_collaborators(project_owner, project_repo).await
+            {
+                for c in &project_collabs {
+                    all_collaborators.insert(c.to_lowercase());
+                }
+            }
+        }
+    }
+
+    let collaborators: Vec<String> = all_collaborators.into_iter().collect();
     Progress::finish_success(
         &pb,
-        &format!("Found {} collaborator(s)", collaborators.len()),
+        &format!(
+            "Found {} collaborator(s) across {} project(s)",
+            collaborators.len(),
+            all_projects.len()
+        ),
     );
 
     Output::info("Current collaborators:");
@@ -372,6 +506,37 @@ pub async fn refresh(project_path: Option<&str>) -> Result<()> {
         println!("  • {}", collab);
     }
     println!();
+
+    // Check for permission drift - recipients who aren't collaborators
+    let recipients_dir = collab_dir.join("recipients");
+    if recipients_dir.exists() {
+        let mut drifted: Vec<String> = Vec::new();
+        for entry in std::fs::read_dir(&recipients_dir)? {
+            let entry = entry?;
+            let filename = entry.file_name().to_string_lossy().to_string();
+            if filename.ends_with(".pub") {
+                let recipient_name = filename.trim_end_matches(".pub");
+                if !collaborators
+                    .iter()
+                    .any(|c| c.eq_ignore_ascii_case(recipient_name))
+                {
+                    drifted.push(recipient_name.to_string());
+                }
+            }
+        }
+
+        if !drifted.is_empty() {
+            println!();
+            Output::warning(
+                "Permission drift detected! These recipients are no longer collaborators:",
+            );
+            for name in &drifted {
+                println!("  • {}", name);
+            }
+            Output::info("They still have access to secrets until you remove their .pub files from the collab repo");
+            println!();
+        }
+    }
 
     // Update members cache
     if let Some(teams) = &mut config.teams {
@@ -386,8 +551,27 @@ pub async fn refresh(project_path: Option<&str>) -> Result<()> {
     let git = GitBackend::open(&collab_dir)?;
     git.pull()?;
 
+    // Update metadata with current authorized list
+    let metadata_path = collab_dir.join(".tether-collab.toml");
+    if metadata_path.exists() {
+        if let Some(teams) = &config.teams {
+            if let Some(collab) = teams.collabs.get(&collab_name) {
+                let metadata = CollabMetadataWrite {
+                    version: 1,
+                    created_by: None,
+                    projects: &collab.projects,
+                    authorized: &collaborators,
+                };
+                let metadata_content = format!(
+                    "# Managed by tether - edit with caution\n{}",
+                    toml::to_string_pretty(&metadata)?
+                );
+                std::fs::write(&metadata_path, metadata_content)?;
+            }
+        }
+    }
+
     // Re-encrypt all secrets with current recipients
-    let recipients_dir = collab_dir.join("recipients");
     let recipients = crate::security::load_recipients(&recipients_dir)?;
 
     if recipients.is_empty() {
@@ -454,7 +638,7 @@ pub async fn refresh(project_path: Option<&str>) -> Result<()> {
 
 /// List all collabs
 pub async fn list() -> Result<()> {
-    let config = Config::load()?;
+    let config = require_collab_feature()?;
 
     let collabs = match &config.teams {
         Some(t) if !t.collabs.is_empty() => &t.collabs,
@@ -489,6 +673,8 @@ pub async fn list() -> Result<()> {
 
 /// Add another project to an existing collab
 pub async fn add_project(project_path: &str) -> Result<()> {
+    let mut config = require_collab_feature()?;
+
     let project_dir = std::path::PathBuf::from(project_path);
     if !project_dir.exists() {
         return Err(anyhow::anyhow!(
@@ -502,7 +688,6 @@ pub async fn add_project(project_path: &str) -> Result<()> {
     let normalized_url = normalize_remote_url(&remote_url);
 
     // Check if already in a collab
-    let config = Config::load()?;
     if config.collab_for_project(&normalized_url).is_some() {
         Output::warning("This project already has a collab");
         return Ok(());
@@ -526,7 +711,6 @@ pub async fn add_project(project_path: &str) -> Result<()> {
     let collab_name = &collabs[selection];
 
     // Update config
-    let mut config = Config::load()?;
     if let Some(teams) = &mut config.teams {
         if let Some(collab) = teams.collabs.get_mut(collab_name) {
             if !collab.projects.contains(&normalized_url) {
@@ -541,18 +725,20 @@ pub async fn add_project(project_path: &str) -> Result<()> {
     if collab_dir.exists() {
         let metadata_path = collab_dir.join(".tether-collab.toml");
         if metadata_path.exists() {
-            // Update projects in metadata (simple approach - rewrite)
+            // Update projects in metadata
             if let Some(teams) = &config.teams {
                 if let Some(collab) = teams.collabs.get(collab_name) {
-                    let metadata = format!(
-                        r#"# Managed by tether - edit with caution
-version = 1
-projects = {:?}
-authorized = {:?}
-"#,
-                        collab.projects, collab.members_cache
+                    let metadata = CollabMetadataWrite {
+                        version: 1,
+                        created_by: None,
+                        projects: &collab.projects,
+                        authorized: &collab.members_cache,
+                    };
+                    let metadata_content = format!(
+                        "# Managed by tether - edit with caution\n{}",
+                        toml::to_string_pretty(&metadata)?
                     );
-                    std::fs::write(&metadata_path, metadata)?;
+                    std::fs::write(&metadata_path, metadata_content)?;
 
                     let git = GitBackend::open(&collab_dir)?;
                     if git.has_changes()? {
@@ -576,7 +762,7 @@ authorized = {:?}
 
 /// Remove a collab
 pub async fn remove(collab_name: Option<&str>) -> Result<()> {
-    let mut config = Config::load()?;
+    let mut config = require_collab_feature()?;
 
     let name = if let Some(n) = collab_name {
         n.to_string()
@@ -597,6 +783,7 @@ pub async fn remove(collab_name: Option<&str>) -> Result<()> {
         let selection = Prompt::select("Remove which collab?", options, 0)?;
         collabs[selection].clone()
     };
+    validate_collab_name(&name)?;
 
     if !Prompt::confirm(&format!("Remove collab '{}'?", name), false)? {
         return Ok(());

--- a/src/cli/commands/collab.rs
+++ b/src/cli/commands/collab.rs
@@ -1,0 +1,619 @@
+use crate::cli::{Output, Progress, Prompt};
+use crate::config::{CollabConfig, Config};
+use crate::github::GitHubCli;
+use crate::sync::git::{get_remote_url, normalize_remote_url};
+use crate::sync::GitBackend;
+use anyhow::Result;
+use serde::Deserialize;
+
+/// Metadata stored in .tether-collab.toml
+#[derive(Debug, Default, Deserialize)]
+#[allow(dead_code)] // Fields used for parsing, may be used in future versions
+struct CollabMetadata {
+    #[serde(default)]
+    version: u32,
+    #[serde(default)]
+    created_by: Option<String>,
+    #[serde(default)]
+    projects: Vec<String>,
+    #[serde(default)]
+    authorized: Vec<String>,
+}
+
+/// Initialize a new collab for the current project
+pub async fn init(project_path: Option<&str>) -> Result<()> {
+    // Determine project directory
+    let project_dir = if let Some(path) = project_path {
+        std::path::PathBuf::from(path)
+    } else {
+        std::env::current_dir()?
+    };
+
+    // Get project's git remote
+    let remote_url = get_remote_url(&project_dir)?;
+    let normalized_url = normalize_remote_url(&remote_url);
+
+    // Parse owner/repo from URL
+    let (owner, repo) = GitHubCli::parse_repo_url(&remote_url)
+        .ok_or_else(|| anyhow::anyhow!("Could not parse GitHub URL from remote: {}", remote_url))?;
+
+    Output::header("Initialize Collaboration");
+    Output::dim(&format!("Project: {}/{}", owner, repo));
+    println!();
+
+    // Check if already has a collab
+    let config = Config::load()?;
+    if config.collab_for_project(&normalized_url).is_some() {
+        Output::warning("This project already has a collab configured");
+        return Ok(());
+    }
+
+    // Ensure GitHub auth
+    if !GitHubCli::is_authenticated().await? {
+        Output::info("Authenticating with GitHub...");
+        GitHubCli::authenticate().await?;
+    }
+
+    // Fetch collaborators
+    let pb = Progress::spinner("Fetching collaborators...");
+    let collaborators = GitHubCli::get_collaborators(&owner, &repo).await?;
+    Progress::finish_success(
+        &pb,
+        &format!("Found {} collaborator(s)", collaborators.len()),
+    );
+
+    if collaborators.is_empty() {
+        Output::warning("No collaborators with write access found");
+        Output::info("Add collaborators to your GitHub repo first");
+        return Ok(());
+    }
+
+    Output::info("Collaborators with write access:");
+    for collab in &collaborators {
+        println!("  • {}", collab);
+    }
+    println!();
+
+    // Create collab sync repo
+    let default_repo_name = format!("{}-dotfiles", repo);
+    let collab_repo_name = Prompt::input("Collab repo name", Some(&default_repo_name))?;
+
+    let username = GitHubCli::get_username().await?;
+    if GitHubCli::repo_exists(&username, &collab_repo_name).await? {
+        Output::warning(&format!("{}/{} already exists", username, collab_repo_name));
+        if !Prompt::confirm("Use existing repository?", true)? {
+            return Ok(());
+        }
+    } else {
+        let pb = Progress::spinner("Creating private collab repository...");
+        GitHubCli::create_repo(&collab_repo_name, true).await?;
+        Progress::finish_success(&pb, "Repository created");
+    }
+
+    let collab_url = format!("git@github.com:{}/{}.git", username, collab_repo_name);
+
+    // Clone collab repo
+    let collab_name = collab_repo_name.clone();
+    let collab_dir = Config::collab_repo_dir(&collab_name)?;
+
+    let pb = Progress::spinner("Setting up collab repository...");
+    std::fs::create_dir_all(collab_dir.parent().unwrap())?;
+
+    if collab_dir.exists() {
+        let git = GitBackend::open(&collab_dir)?;
+        git.pull()?;
+    } else {
+        GitBackend::clone(&collab_url, &collab_dir)?;
+    }
+
+    // Create recipients directory and add self
+    let recipients_dir = collab_dir.join("recipients");
+    std::fs::create_dir_all(&recipients_dir)?;
+
+    // Add creator's identity
+    if let Ok(identity_pub) = crate::security::get_public_key() {
+        let pub_file = recipients_dir.join(format!("{}.pub", username));
+        std::fs::write(&pub_file, identity_pub)?;
+    }
+
+    // Create projects directory
+    std::fs::create_dir_all(collab_dir.join("projects"))?;
+
+    // Create .tether-collab.toml metadata
+    let metadata = format!(
+        r#"# Managed by tether - edit with caution
+version = 1
+created_by = "{}"
+projects = ["{}"]
+authorized = {:?}
+"#,
+        username, normalized_url, collaborators
+    );
+    std::fs::write(collab_dir.join(".tether-collab.toml"), metadata)?;
+
+    // Commit and push
+    let git = GitBackend::open(&collab_dir)?;
+    if git.has_changes()? {
+        git.commit("Initialize collab", &username)?;
+        git.push()?;
+    }
+    Progress::finish_success(&pb, "Collab repository ready");
+
+    // Update config
+    let mut config = Config::load()?;
+    let teams = config.teams.get_or_insert_with(Default::default);
+    teams.collabs.insert(
+        collab_name.clone(),
+        CollabConfig {
+            sync_url: collab_url.clone(),
+            projects: vec![normalized_url.clone()],
+            members_cache: collaborators,
+            last_refresh: Some(chrono::Utc::now()),
+            enabled: true,
+        },
+    );
+    config.save()?;
+
+    println!();
+    Output::success("Collab initialized!");
+    println!();
+    Output::info("Share this URL with collaborators:");
+    println!("  {}", collab_url);
+    println!();
+    Output::info("They can join with:");
+    println!("  tether collab join {}", collab_url);
+
+    Ok(())
+}
+
+/// Join an existing collab
+pub async fn join(url: &str) -> Result<()> {
+    Output::header("Join Collaboration");
+    println!();
+
+    // Parse collab name from URL
+    let (owner, repo) = GitHubCli::parse_repo_url(url)
+        .ok_or_else(|| anyhow::anyhow!("Could not parse GitHub URL: {}", url))?;
+    let collab_name = repo.clone();
+
+    // Check if already joined
+    let config = Config::load()?;
+    if let Some(teams) = &config.teams {
+        if teams.collabs.contains_key(&collab_name) {
+            Output::warning("Already joined this collab");
+            return Ok(());
+        }
+    }
+
+    // Clone collab repo
+    let collab_dir = Config::collab_repo_dir(&collab_name)?;
+    std::fs::create_dir_all(collab_dir.parent().unwrap())?;
+
+    let pb = Progress::spinner("Cloning collab repository...");
+    GitBackend::clone(url, &collab_dir)?;
+    Progress::finish_success(&pb, "Repository cloned");
+
+    // Ensure user has identity
+    let identity_pub = match crate::security::get_public_key() {
+        Ok(key) => key,
+        Err(_) => {
+            Output::info("Creating age identity...");
+            crate::cli::commands::identity::init().await?;
+            crate::security::get_public_key()?
+        }
+    };
+
+    // Add self as recipient
+    let username = GitHubCli::get_username().await?;
+    let recipients_dir = collab_dir.join("recipients");
+    std::fs::create_dir_all(&recipients_dir)?;
+    let pub_file = recipients_dir.join(format!("{}.pub", username));
+    std::fs::write(&pub_file, identity_pub)?;
+
+    // Commit and push
+    let git = GitBackend::open(&collab_dir)?;
+    if git.has_changes()? {
+        git.commit(&format!("Add recipient: {}", username), &username)?;
+        git.push()?;
+        Output::success(&format!("Added {} as recipient", username));
+    }
+
+    // Read metadata to get projects
+    let metadata_path = collab_dir.join(".tether-collab.toml");
+    let projects = if metadata_path.exists() {
+        let content = std::fs::read_to_string(&metadata_path)?;
+        let metadata: CollabMetadata = toml::from_str(&content).unwrap_or_default();
+        metadata.projects
+    } else {
+        Vec::new()
+    };
+
+    // Update config
+    let mut config = Config::load()?;
+    let teams = config.teams.get_or_insert_with(Default::default);
+    teams.collabs.insert(
+        collab_name.clone(),
+        CollabConfig {
+            sync_url: url.to_string(),
+            projects,
+            members_cache: vec![owner, username],
+            last_refresh: Some(chrono::Utc::now()),
+            enabled: true,
+        },
+    );
+    config.save()?;
+
+    println!();
+    Output::success("Joined collab!");
+    Output::info("Run 'tether sync' to receive shared secrets");
+    Output::warning("Note: Owner must run 'tether collab refresh' to re-encrypt secrets for you");
+
+    Ok(())
+}
+
+/// Add a secret file to the collab
+pub async fn add(file: &str, project_path: Option<&str>) -> Result<()> {
+    // Determine project directory
+    let project_dir = if let Some(path) = project_path {
+        std::path::PathBuf::from(path)
+    } else {
+        std::env::current_dir()?
+    };
+
+    // Get project's git remote
+    let remote_url = get_remote_url(&project_dir)?;
+    let normalized_url = normalize_remote_url(&remote_url);
+
+    // Find collab for this project
+    let config = Config::load()?;
+    let (collab_name, _collab_config) =
+        config.collab_for_project(&normalized_url).ok_or_else(|| {
+            anyhow::anyhow!(
+                "No collab configured for this project. Run 'tether collab init' first."
+            )
+        })?;
+
+    let collab_dir = Config::collab_repo_dir(&collab_name)?;
+    if !collab_dir.exists() {
+        return Err(anyhow::anyhow!(
+            "Collab repo not found. Try 'tether collab join' again."
+        ));
+    }
+
+    // Pull latest
+    let git = GitBackend::open(&collab_dir)?;
+    git.pull()?;
+
+    // Load recipients
+    let recipients_dir = collab_dir.join("recipients");
+    let recipients = crate::security::load_recipients(&recipients_dir)?;
+    if recipients.is_empty() {
+        return Err(anyhow::anyhow!(
+            "No recipients found in collab. Add recipients first."
+        ));
+    }
+
+    // Read file to encrypt
+    let file_path = project_dir.join(file);
+    if !file_path.exists() {
+        return Err(anyhow::anyhow!("File not found: {}", file_path.display()));
+    }
+    let content = std::fs::read(&file_path)?;
+
+    // Encrypt to all recipients
+    let encrypted = crate::security::encrypt_to_recipients(&content, &recipients)?;
+
+    // Write to collab repo
+    let dest_dir = collab_dir.join("projects").join(&normalized_url);
+    std::fs::create_dir_all(&dest_dir)?;
+    let dest_file = dest_dir.join(format!("{}.age", file));
+    std::fs::write(&dest_file, encrypted)?;
+
+    // Commit and push
+    if git.has_changes()? {
+        let username = GitHubCli::get_username()
+            .await
+            .unwrap_or_else(|_| "unknown".to_string());
+        git.commit(
+            &format!("Add secret: {}/{}", normalized_url, file),
+            &username,
+        )?;
+        git.push()?;
+    }
+
+    Output::success(&format!("Added {} to collab", file));
+    Output::info(&format!("Encrypted to {} recipient(s)", recipients.len()));
+
+    Ok(())
+}
+
+/// Refresh collaborators from GitHub and re-encrypt secrets
+pub async fn refresh(project_path: Option<&str>) -> Result<()> {
+    // Determine project directory
+    let project_dir = if let Some(path) = project_path {
+        std::path::PathBuf::from(path)
+    } else {
+        std::env::current_dir()?
+    };
+
+    // Get project's git remote
+    let remote_url = get_remote_url(&project_dir)?;
+    let normalized_url = normalize_remote_url(&remote_url);
+
+    // Find collab for this project
+    let mut config = Config::load()?;
+    let (collab_name, _) = config
+        .collab_for_project(&normalized_url)
+        .ok_or_else(|| anyhow::anyhow!("No collab configured for this project"))?;
+    let collab_name = collab_name.clone();
+
+    let collab_dir = Config::collab_repo_dir(&collab_name)?;
+    if !collab_dir.exists() {
+        return Err(anyhow::anyhow!("Collab repo not found"));
+    }
+
+    // Parse owner/repo from project URL
+    let (owner, repo) = GitHubCli::parse_repo_url(&remote_url)
+        .ok_or_else(|| anyhow::anyhow!("Could not parse GitHub URL"))?;
+
+    Output::header("Refresh Collaborators");
+    println!();
+
+    // Fetch current collaborators
+    let pb = Progress::spinner("Fetching collaborators from GitHub...");
+    let collaborators = GitHubCli::get_collaborators(&owner, &repo).await?;
+    Progress::finish_success(
+        &pb,
+        &format!("Found {} collaborator(s)", collaborators.len()),
+    );
+
+    Output::info("Current collaborators:");
+    for collab in &collaborators {
+        println!("  • {}", collab);
+    }
+    println!();
+
+    // Update members cache
+    if let Some(teams) = &mut config.teams {
+        if let Some(collab_config) = teams.collabs.get_mut(&collab_name) {
+            collab_config.members_cache = collaborators.clone();
+            collab_config.last_refresh = Some(chrono::Utc::now());
+        }
+    }
+    config.save()?;
+
+    // Pull latest collab repo
+    let git = GitBackend::open(&collab_dir)?;
+    git.pull()?;
+
+    // Re-encrypt all secrets with current recipients
+    let recipients_dir = collab_dir.join("recipients");
+    let recipients = crate::security::load_recipients(&recipients_dir)?;
+
+    if recipients.is_empty() {
+        Output::warning("No recipients found - secrets won't be re-encrypted");
+        return Ok(());
+    }
+
+    let projects_dir = collab_dir.join("projects");
+    if !projects_dir.exists() {
+        Output::info("No secrets to re-encrypt");
+        return Ok(());
+    }
+
+    // Load user's identity for decryption
+    let identity = crate::security::load_identity(None)?;
+
+    let pb = Progress::spinner("Re-encrypting secrets...");
+    let mut count = 0;
+
+    for entry in walkdir::WalkDir::new(&projects_dir) {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let path = entry.path();
+        if !path.to_string_lossy().ends_with(".age") {
+            continue;
+        }
+
+        // Decrypt with identity
+        let encrypted = std::fs::read(path)?;
+        match crate::security::decrypt_with_identity(&encrypted, &identity) {
+            Ok(decrypted) => {
+                // Re-encrypt to current recipients
+                let re_encrypted = crate::security::encrypt_to_recipients(&decrypted, &recipients)?;
+                std::fs::write(path, re_encrypted)?;
+                count += 1;
+            }
+            Err(e) => {
+                Output::warning(&format!("Could not decrypt {}: {}", path.display(), e));
+            }
+        }
+    }
+
+    Progress::finish_success(&pb, &format!("Re-encrypted {} secret(s)", count));
+
+    // Commit and push
+    if git.has_changes()? {
+        let username = GitHubCli::get_username()
+            .await
+            .unwrap_or_else(|_| "unknown".to_string());
+        git.commit("Re-encrypt secrets for updated recipients", &username)?;
+        git.push()?;
+        Output::success("Pushed updated secrets");
+    }
+
+    Ok(())
+}
+
+/// List all collabs
+pub async fn list() -> Result<()> {
+    let config = Config::load()?;
+
+    let collabs = match &config.teams {
+        Some(t) if !t.collabs.is_empty() => &t.collabs,
+        _ => {
+            Output::info("No collabs configured");
+            Output::info("Run 'tether collab init' in a project directory to create one");
+            return Ok(());
+        }
+    };
+
+    Output::section("Collaborations");
+    println!();
+
+    for (name, collab) in collabs {
+        let status = if collab.enabled {
+            "enabled"
+        } else {
+            "disabled"
+        };
+        println!("{} ({})", name, status);
+        println!("  URL: {}", collab.sync_url);
+        println!("  Projects: {}", collab.projects.join(", "));
+        println!("  Members: {}", collab.members_cache.join(", "));
+        if let Some(refresh) = &collab.last_refresh {
+            println!("  Last refresh: {}", refresh.format("%Y-%m-%d %H:%M UTC"));
+        }
+        println!();
+    }
+
+    Ok(())
+}
+
+/// Add another project to an existing collab
+pub async fn add_project(project_path: &str) -> Result<()> {
+    let project_dir = std::path::PathBuf::from(project_path);
+    if !project_dir.exists() {
+        return Err(anyhow::anyhow!(
+            "Project directory not found: {}",
+            project_path
+        ));
+    }
+
+    // Get project's git remote
+    let remote_url = get_remote_url(&project_dir)?;
+    let normalized_url = normalize_remote_url(&remote_url);
+
+    // Check if already in a collab
+    let config = Config::load()?;
+    if config.collab_for_project(&normalized_url).is_some() {
+        Output::warning("This project already has a collab");
+        return Ok(());
+    }
+
+    // List available collabs
+    let collabs: Vec<String> = config
+        .teams
+        .as_ref()
+        .map(|t| t.collabs.keys().cloned().collect())
+        .unwrap_or_default();
+
+    if collabs.is_empty() {
+        Output::error("No collabs available. Create one with 'tether collab init' first.");
+        return Ok(());
+    }
+
+    // Select collab to add to
+    let options: Vec<&str> = collabs.iter().map(|s| s.as_str()).collect();
+    let selection = Prompt::select("Add project to which collab?", options, 0)?;
+    let collab_name = &collabs[selection];
+
+    // Update config
+    let mut config = Config::load()?;
+    if let Some(teams) = &mut config.teams {
+        if let Some(collab) = teams.collabs.get_mut(collab_name) {
+            if !collab.projects.contains(&normalized_url) {
+                collab.projects.push(normalized_url.clone());
+            }
+        }
+    }
+    config.save()?;
+
+    // Update collab repo metadata
+    let collab_dir = Config::collab_repo_dir(collab_name)?;
+    if collab_dir.exists() {
+        let metadata_path = collab_dir.join(".tether-collab.toml");
+        if metadata_path.exists() {
+            // Update projects in metadata (simple approach - rewrite)
+            if let Some(teams) = &config.teams {
+                if let Some(collab) = teams.collabs.get(collab_name) {
+                    let metadata = format!(
+                        r#"# Managed by tether - edit with caution
+version = 1
+projects = {:?}
+authorized = {:?}
+"#,
+                        collab.projects, collab.members_cache
+                    );
+                    std::fs::write(&metadata_path, metadata)?;
+
+                    let git = GitBackend::open(&collab_dir)?;
+                    if git.has_changes()? {
+                        let username = GitHubCli::get_username()
+                            .await
+                            .unwrap_or_else(|_| "unknown".to_string());
+                        git.commit(&format!("Add project: {}", normalized_url), &username)?;
+                        git.push()?;
+                    }
+                }
+            }
+        }
+    }
+
+    Output::success(&format!(
+        "Added {} to collab '{}'",
+        normalized_url, collab_name
+    ));
+    Ok(())
+}
+
+/// Remove a collab
+pub async fn remove(collab_name: Option<&str>) -> Result<()> {
+    let mut config = Config::load()?;
+
+    let name = if let Some(n) = collab_name {
+        n.to_string()
+    } else {
+        // List available collabs
+        let collabs: Vec<String> = config
+            .teams
+            .as_ref()
+            .map(|t| t.collabs.keys().cloned().collect())
+            .unwrap_or_default();
+
+        if collabs.is_empty() {
+            Output::info("No collabs to remove");
+            return Ok(());
+        }
+
+        let options: Vec<&str> = collabs.iter().map(|s| s.as_str()).collect();
+        let selection = Prompt::select("Remove which collab?", options, 0)?;
+        collabs[selection].clone()
+    };
+
+    if !Prompt::confirm(&format!("Remove collab '{}'?", name), false)? {
+        return Ok(());
+    }
+
+    // Remove from config
+    if let Some(teams) = &mut config.teams {
+        teams.collabs.remove(&name);
+    }
+    config.save()?;
+
+    // Remove local directory
+    let collab_dir = Config::collab_dir(&name)?;
+    if collab_dir.exists() {
+        std::fs::remove_dir_all(&collab_dir)?;
+    }
+
+    Output::success(&format!("Removed collab '{}'", name));
+    Ok(())
+}

--- a/src/cli/commands/collab.rs
+++ b/src/cli/commands/collab.rs
@@ -804,3 +804,35 @@ pub async fn remove(collab_name: Option<&str>) -> Result<()> {
     Output::success(&format!("Removed collab '{}'", name));
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_collab_name_valid() {
+        assert!(validate_collab_name("my-project").is_ok());
+        assert!(validate_collab_name("project_dotfiles").is_ok());
+        assert!(validate_collab_name("MyProject123").is_ok());
+    }
+
+    #[test]
+    fn test_validate_collab_name_empty() {
+        assert!(validate_collab_name("").is_err());
+    }
+
+    #[test]
+    fn test_validate_collab_name_path_traversal() {
+        assert!(validate_collab_name("..").is_err());
+        assert!(validate_collab_name("foo/bar").is_err());
+        assert!(validate_collab_name("foo\\bar").is_err());
+        assert!(validate_collab_name("../etc").is_err());
+        assert!(validate_collab_name("foo/..").is_err());
+    }
+
+    #[test]
+    fn test_validate_collab_name_hidden() {
+        assert!(validate_collab_name(".hidden").is_err());
+        assert!(validate_collab_name(".git").is_err());
+    }
+}

--- a/src/cli/commands/diff.rs
+++ b/src/cli/commands/diff.rs
@@ -29,6 +29,12 @@ pub async fn run(machine: Option<&str>) -> Result<()> {
         }
     };
 
+    if !config.has_personal_features() {
+        Output::warning("Diff not available without personal features (no personal repo)");
+        Output::info("Use 'tether team files diff' for team file differences");
+        return Ok(());
+    }
+
     let state = SyncState::load()?;
     let sync_path = SyncEngine::sync_path()?;
     let home = home::home_dir().ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?;

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -108,27 +108,12 @@ pub async fn run(repo: Option<&str>, no_daemon: bool, team_only: bool) -> Result
         }
     } else {
         // No personal features - create minimal .tether directory
+        // Note: We don't clear dotfiles/packages config, just disable syncing
+        // This preserves settings if user re-enables features later
         let tether_dir = Config::config_dir()?;
         std::fs::create_dir_all(&tether_dir)?;
         config.backend.url = String::new();
         config.security.encrypt_dotfiles = false;
-
-        // Disable package managers when personal packages disabled
-        if !config.features.personal_packages {
-            config.packages.brew.enabled = false;
-            config.packages.npm.enabled = false;
-            config.packages.pnpm.enabled = false;
-            config.packages.bun.enabled = false;
-            config.packages.gem.enabled = false;
-            config.packages.uv.enabled = false;
-        }
-
-        // Clear dotfiles when personal dotfiles disabled
-        if !config.features.personal_dotfiles {
-            config.dotfiles.files.clear();
-            config.dotfiles.dirs.clear();
-            config.project_configs.enabled = false;
-        }
     }
 
     config.save()?;

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -1,10 +1,10 @@
 use crate::cli::{Output, Progress, Prompt};
-use crate::config::Config;
+use crate::config::{Config, FeaturesConfig};
 use crate::github::GitHubCli;
 use crate::sync::{GitBackend, SyncEngine, SyncState};
 use anyhow::Result;
 
-pub async fn run(repo: Option<&str>, no_daemon: bool) -> Result<()> {
+pub async fn run(repo: Option<&str>, no_daemon: bool, team_only: bool) -> Result<()> {
     Output::header("Welcome to Tether!");
     Output::dim("Sync your dev environment across machines");
     println!();
@@ -16,15 +16,23 @@ pub async fn run(repo: Option<&str>, no_daemon: bool) -> Result<()> {
     if already_initialized {
         Output::info("Tether is already initialized");
 
-        // Sync first to ensure we don't lose any data
-        Output::info("Running sync to preserve your data...");
-        if let Err(e) = super::sync::run(false, false).await {
-            Output::warning(&format!("Sync failed: {}", e));
-            if !Prompt::confirm(
-                "Continue with reinit anyway? (may lose unsynced changes)",
-                false,
-            )? {
-                return Ok(());
+        // Sync first to ensure we don't lose any data (skip if no personal repo)
+        let existing_config = Config::load().ok();
+        let has_personal = existing_config
+            .as_ref()
+            .map(|c| c.has_personal_repo())
+            .unwrap_or(false);
+
+        if has_personal {
+            Output::info("Running sync to preserve your data...");
+            if let Err(e) = super::sync::run(false, false).await {
+                Output::warning(&format!("Sync failed: {}", e));
+                if !Prompt::confirm(
+                    "Continue with reinit anyway? (may lose unsynced changes)",
+                    false,
+                )? {
+                    return Ok(());
+                }
             }
         }
 
@@ -40,93 +48,195 @@ pub async fn run(repo: Option<&str>, no_daemon: bool) -> Result<()> {
         Config::default()
     };
 
-    // Get repository URL (use existing if reinitializing, unless explicitly provided)
-    let repo_url = if let Some(url) = repo {
-        url.to_string()
-    } else if already_initialized && !config.backend.url.is_empty() {
-        Output::dim(&format!("  Current repo: {}", config.backend.url));
-        if Prompt::confirm("Keep current repository?", true)? {
-            config.backend.url.clone()
+    // Legacy --team-only flag support
+    if team_only {
+        config.features.personal_dotfiles = false;
+        config.features.personal_packages = false;
+        config.features.team_dotfiles = true;
+    } else {
+        // Feature selection prompt
+        let features = select_features(&config.features)?;
+        config.features = features;
+    }
+
+    let needs_personal_repo =
+        config.features.personal_dotfiles || config.features.personal_packages;
+
+    // Personal repo setup (if personal features enabled)
+    if needs_personal_repo {
+        let repo_url = if let Some(url) = repo {
+            url.to_string()
+        } else if already_initialized && !config.backend.url.is_empty() {
+            Output::dim(&format!("  Current repo: {}", config.backend.url));
+            if Prompt::confirm("Keep current repository?", true)? {
+                config.backend.url.clone()
+            } else {
+                setup_repository().await?
+            }
         } else {
             setup_repository().await?
+        };
+
+        if repo_url.is_empty() {
+            Output::error("Repository URL cannot be empty");
+            return Err(anyhow::anyhow!("Repository URL is required"));
         }
-    } else {
-        setup_repository().await?
-    };
 
-    if repo_url.is_empty() {
-        Output::error("Repository URL cannot be empty");
-        return Err(anyhow::anyhow!("Repository URL is required"));
-    }
+        config.backend.url = repo_url.clone();
 
-    // Create .tether directory
-    let tether_dir = Config::config_dir()?;
-    std::fs::create_dir_all(&tether_dir)?;
+        // Create .tether directory
+        let tether_dir = Config::config_dir()?;
+        std::fs::create_dir_all(&tether_dir)?;
 
-    // Clone or pull repository
-    let sync_path = SyncEngine::sync_path()?;
-
-    if sync_path.exists() {
-        let git = GitBackend::open(&sync_path)?;
-        git.pull()?;
-    } else {
-        GitBackend::clone(&repo_url, &sync_path)?;
-    }
-
-    // Update and save config (preserves existing settings)
-    config.backend.url = repo_url;
-    config.save()?;
-
-    // Setup encryption if enabled
-    if config.security.encrypt_dotfiles {
-        if crate::security::has_encryption_key() {
-            Output::info("Encrypted key found. Enter passphrase:");
-            let passphrase = Prompt::password("Passphrase")?;
-            crate::security::unlock_with_passphrase(&passphrase)?;
+        // Clone or pull repository
+        let sync_path = SyncEngine::sync_path()?;
+        if sync_path.exists() {
+            let git = GitBackend::open(&sync_path)?;
+            git.pull()?;
         } else {
-            Output::info("Creating encryption key. Choose a passphrase (min 8 chars).");
-            println!();
+            GitBackend::clone(&repo_url, &sync_path)?;
+        }
 
-            let passphrase = Prompt::password("Passphrase")?;
-            let confirm = Prompt::password("Confirm passphrase")?;
+        // Create sync repo structure
+        std::fs::create_dir_all(sync_path.join("manifests"))?;
+        std::fs::create_dir_all(sync_path.join("dotfiles"))?;
+        std::fs::create_dir_all(sync_path.join("machines"))?;
 
-            if passphrase != confirm {
-                return Err(anyhow::anyhow!("Passphrases do not match"));
-            }
+        // Setup encryption if enabled
+        if config.security.encrypt_dotfiles {
+            setup_encryption()?;
+        }
+    } else {
+        // No personal features - create minimal .tether directory
+        let tether_dir = Config::config_dir()?;
+        std::fs::create_dir_all(&tether_dir)?;
+        config.backend.url = String::new();
+        config.security.encrypt_dotfiles = false;
 
-            if passphrase.len() < 8 {
-                return Err(anyhow::anyhow!("Passphrase must be at least 8 characters"));
-            }
+        // Disable package managers when personal packages disabled
+        if !config.features.personal_packages {
+            config.packages.brew.enabled = false;
+            config.packages.npm.enabled = false;
+            config.packages.pnpm.enabled = false;
+            config.packages.bun.enabled = false;
+            config.packages.gem.enabled = false;
+            config.packages.uv.enabled = false;
+        }
 
-            let key = crate::security::encryption::generate_key();
-            crate::security::store_encryption_key_with_passphrase(&key, &passphrase)?;
-            crate::security::unlock_with_passphrase(&passphrase)?;
+        // Clear dotfiles when personal dotfiles disabled
+        if !config.features.personal_dotfiles {
+            config.dotfiles.files.clear();
+            config.dotfiles.dirs.clear();
+            config.project_configs.enabled = false;
         }
     }
+
+    config.save()?;
 
     // Create initial state
     let state = SyncState::load()?;
     state.save()?;
 
-    // Create sync repo structure
-    std::fs::create_dir_all(sync_path.join("manifests"))?;
-    std::fs::create_dir_all(sync_path.join("dotfiles"))?;
-    std::fs::create_dir_all(sync_path.join("machines"))?;
+    // Initial sync (only if personal features enabled)
+    if needs_personal_repo {
+        super::sync::run(false, false).await?;
+    }
 
-    // Initial sync
-    super::sync::run(false, false).await?;
-
-    // Install daemon for auto-start on login (unless opted out)
+    // Install daemon for auto-sync (unless opted out)
     if !no_daemon {
         if let Err(err) = super::daemon::install().await {
             Output::warning(&format!("Failed to install daemon: {}", err));
         }
     }
 
+    let sync_path = SyncEngine::sync_path()?;
     Output::success("Initialized!");
     println!("  Config: {}", config_path.display());
-    println!("  Sync:   {}", sync_path.display());
+    if needs_personal_repo {
+        println!("  Sync:   {}", sync_path.display());
+    }
 
+    // Follow-up setup for selected features
+    println!();
+
+    if config.features.team_dotfiles {
+        Output::info("Team dotfiles enabled. Set up your team:");
+        println!("  tether team setup");
+        println!();
+    }
+
+    if config.features.collab_secrets {
+        Output::info("Project collaboration enabled. In a project directory:");
+        println!("  tether collab init");
+        println!();
+    }
+
+    Ok(())
+}
+
+/// Prompt user to select features
+fn select_features(current: &FeaturesConfig) -> Result<FeaturesConfig> {
+    let options = vec![
+        "Personal dotfiles (shell, git, etc.)",
+        "Personal packages (brew, npm, etc.)",
+        "Team dotfiles (org-based)",
+        "Project secrets with collaborators",
+    ];
+
+    // Default selections based on current config
+    let mut defaults = Vec::new();
+    if current.personal_dotfiles {
+        defaults.push(0);
+    }
+    if current.personal_packages {
+        defaults.push(1);
+    }
+    if current.team_dotfiles {
+        defaults.push(2);
+    }
+    if current.collab_secrets {
+        defaults.push(3);
+    }
+    // Default to personal dotfiles + packages for new installs
+    if defaults.is_empty() {
+        defaults = vec![0, 1];
+    }
+
+    let selected = Prompt::multi_select("What would you like to sync?", options, &defaults)?;
+
+    Ok(FeaturesConfig {
+        personal_dotfiles: selected.contains(&0),
+        personal_packages: selected.contains(&1),
+        team_dotfiles: selected.contains(&2),
+        collab_secrets: selected.contains(&3),
+        team_layering: current.team_layering, // Preserve hidden setting
+    })
+}
+
+fn setup_encryption() -> Result<()> {
+    if crate::security::has_encryption_key() {
+        Output::info("Encrypted key found. Enter passphrase:");
+        let passphrase = Prompt::password("Passphrase")?;
+        crate::security::unlock_with_passphrase(&passphrase)?;
+    } else {
+        Output::info("Creating encryption key. Choose a passphrase (min 8 chars).");
+        println!();
+
+        let passphrase = Prompt::password("Passphrase")?;
+        let confirm = Prompt::password("Confirm passphrase")?;
+
+        if passphrase != confirm {
+            return Err(anyhow::anyhow!("Passphrases do not match"));
+        }
+
+        if passphrase.len() < 8 {
+            return Err(anyhow::anyhow!("Passphrase must be at least 8 characters"));
+        }
+
+        let key = crate::security::encryption::generate_key();
+        crate::security::store_encryption_key_with_passphrase(&key, &passphrase)?;
+        crate::security::unlock_with_passphrase(&passphrase)?;
+    }
     Ok(())
 }
 

--- a/src/cli/commands/machines.rs
+++ b/src/cli/commands/machines.rs
@@ -1,4 +1,5 @@
 use crate::cli::{Output, Prompt};
+use crate::config::Config;
 use crate::sync::{GitBackend, MachineState, SyncEngine, SyncState};
 use anyhow::Result;
 use chrono::Local;
@@ -6,6 +7,12 @@ use comfy_table::{presets::UTF8_FULL, Attribute, Cell, Color, ContentArrangement
 use owo_colors::OwoColorize;
 
 pub async fn list() -> Result<()> {
+    let config = Config::load()?;
+    if !config.has_personal_features() {
+        Output::warning("Machine management not available in team-only mode");
+        return Ok(());
+    }
+
     let sync_path = SyncEngine::sync_path()?;
     let machines = MachineState::list_all(&sync_path)?;
 
@@ -62,6 +69,12 @@ pub async fn list() -> Result<()> {
 }
 
 pub async fn rename(old: &str, new: &str) -> Result<()> {
+    let config = Config::load()?;
+    if !config.has_personal_features() {
+        Output::warning("Machine management not available in team-only mode");
+        return Ok(());
+    }
+
     let sync_path = SyncEngine::sync_path()?;
     let machines_dir = sync_path.join("machines");
 
@@ -107,6 +120,12 @@ pub async fn rename(old: &str, new: &str) -> Result<()> {
 }
 
 pub async fn remove(name: &str) -> Result<()> {
+    let config = Config::load()?;
+    if !config.has_personal_features() {
+        Output::warning("Machine management not available in team-only mode");
+        return Ok(());
+    }
+
     let state = SyncState::load()?;
 
     if state.machine_id == name {

--- a/src/cli/commands/resolve.rs
+++ b/src/cli/commands/resolve.rs
@@ -7,6 +7,12 @@ use sha2::{Digest, Sha256};
 
 pub async fn run(file: Option<&str>) -> Result<()> {
     let config = Config::load()?;
+
+    if !config.has_personal_features() {
+        Output::warning("Resolve not available without personal features");
+        return Ok(());
+    }
+
     let mut conflict_state = ConflictState::load()?;
 
     if conflict_state.conflicts.is_empty() {

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -306,7 +306,10 @@ pub async fn run() -> Result<()> {
             Cell::new("Packages")
                 .add_attribute(Attribute::Bold)
                 .fg(Color::Cyan),
-            Cell::new("Last Sync")
+            Cell::new("Modified")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Cyan),
+            Cell::new("Upgraded")
                 .add_attribute(Attribute::Bold)
                 .fg(Color::Cyan),
         ]);
@@ -316,10 +319,15 @@ pub async fn run() -> Result<()> {
                 Cell::new(format!("{} {}", Output::CHECK, manager)).fg(Color::Green),
                 Cell::new(
                     pkg_state
-                        .last_sync
-                        .with_timezone(&Local)
-                        .format("%Y-%m-%d %H:%M")
-                        .to_string(),
+                        .last_modified
+                        .map(|t| t.with_timezone(&Local).format("%Y-%m-%d %H:%M").to_string())
+                        .unwrap_or_else(|| "-".to_string()),
+                ),
+                Cell::new(
+                    pkg_state
+                        .last_upgrade
+                        .map(|t| t.with_timezone(&Local).format("%Y-%m-%d %H:%M").to_string())
+                        .unwrap_or_else(|| "-".to_string()),
                 ),
             ]);
         }

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -26,6 +26,25 @@ pub async fn run() -> Result<()> {
     Output::section("Tether Status");
     println!();
 
+    // Features summary (one line)
+    let mut enabled_features = Vec::new();
+    if config.features.personal_dotfiles {
+        enabled_features.push("dotfiles");
+    }
+    if config.features.personal_packages {
+        enabled_features.push("packages");
+    }
+    if config.features.team_dotfiles {
+        enabled_features.push("team");
+    }
+    if config.features.collab_secrets {
+        enabled_features.push("collab");
+    }
+    if !enabled_features.is_empty() {
+        Output::dim(&format!("Features: {}", enabled_features.join(", ")));
+        println!();
+    }
+
     // Daemon status
     let pid = read_daemon_pid()?;
     let (status_label, is_running) = match pid {
@@ -125,8 +144,8 @@ pub async fn run() -> Result<()> {
         .iter()
         .partition(|(file, _)| !file.starts_with("project:"));
 
-    // Dotfiles - minimal table for lists
-    if !dotfiles.is_empty() {
+    // Dotfiles - minimal table for lists (only show if feature enabled)
+    if config.features.personal_dotfiles && !dotfiles.is_empty() {
         let mut files_table = Output::table_minimal();
         files_table.set_header(vec![
             Cell::new("Dotfiles")
@@ -161,7 +180,7 @@ pub async fn run() -> Result<()> {
         }
         println!("{files_table}");
         println!();
-    } else {
+    } else if config.features.personal_dotfiles {
         Output::dim("  No dotfiles synced yet");
         println!();
     }
@@ -280,8 +299,8 @@ pub async fn run() -> Result<()> {
         }
     }
 
-    // Packages - minimal table for lists
-    if !state.packages.is_empty() {
+    // Packages - minimal table for lists (only show if feature enabled)
+    if config.features.personal_packages && !state.packages.is_empty() {
         let mut packages_table = Output::table_minimal();
         packages_table.set_header(vec![
             Cell::new("Packages")
@@ -306,7 +325,7 @@ pub async fn run() -> Result<()> {
         }
         println!("{packages_table}");
         println!();
-    } else {
+    } else if config.features.personal_packages {
         Output::dim("  No packages synced yet");
         println!();
     }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -180,6 +180,7 @@ pub async fn run(dry_run: bool, _force: bool) -> Result<()> {
         import_packages(
             &config,
             &sync_path,
+            &mut state,
             &machine_state,
             false, // interactive mode
             &deferred_casks,

--- a/src/cli/commands/team.rs
+++ b/src/cli/commands/team.rs
@@ -1277,7 +1277,9 @@ pub async fn orgs_add(org: &str, yes: bool) -> Result<()> {
                         pb.finish_and_clear();
                         Output::error(&format!("Migration failed: {}", e));
                         Output::dim("Personal secrets were NOT deleted (safe).");
-                        Output::dim("Fix the issue and run 'tether team projects migrate' to retry.");
+                        Output::dim(
+                            "Fix the issue and run 'tether team projects migrate' to retry.",
+                        );
                     }
                 }
             } else {
@@ -1445,8 +1447,9 @@ fn migrate_personal_to_team(
     let personal_key = crate::security::get_encryption_key()?;
 
     // Load user identity for verification (test decrypt after encrypt)
-    let identity = crate::security::load_identity(None)
-        .map_err(|_| anyhow::anyhow!("Identity required for migration. Run 'tether identity unlock' first."))?;
+    let identity = crate::security::load_identity(None).map_err(|_| {
+        anyhow::anyhow!("Identity required for migration. Run 'tether identity unlock' first.")
+    })?;
 
     // Load team recipients for re-encryption
     let recipients_dir = team_repo_dir.join("recipients");
@@ -1508,11 +1511,13 @@ fn migrate_personal_to_team(
             let team_encrypted = crate::security::encrypt_to_recipients(&plaintext, &recipients)?;
 
             // Verify encryption by test-decrypting (round-trip check)
-            crate::security::decrypt_with_identity(&team_encrypted, &identity)
-                .map_err(|e| anyhow::anyhow!(
+            crate::security::decrypt_with_identity(&team_encrypted, &identity).map_err(|e| {
+                anyhow::anyhow!(
                     "Verification failed for {}: encrypted file not decryptable: {}",
-                    file_path.display(), e
-                ))?;
+                    file_path.display(),
+                    e
+                )
+            })?;
 
             // Write to team repo
             if let Some(parent) = team_dest_file.parent() {
@@ -1521,8 +1526,9 @@ fn migrate_personal_to_team(
             std::fs::write(&team_dest_file, &team_encrypted)?;
 
             // Verify the team file exists and has content
-            let metadata = std::fs::metadata(&team_dest_file)
-                .map_err(|e| anyhow::anyhow!("Failed to verify {}: {}", team_dest_file.display(), e))?;
+            let metadata = std::fs::metadata(&team_dest_file).map_err(|e| {
+                anyhow::anyhow!("Failed to verify {}: {}", team_dest_file.display(), e)
+            })?;
             if metadata.len() == 0 {
                 anyhow::bail!(
                     "Migration verification failed: {} was written but is empty",
@@ -1540,7 +1546,10 @@ fn migrate_personal_to_team(
     }
 
     if skipped_existing > 0 {
-        Output::dim(&format!("  Skipped {} file(s) already in team repo", skipped_existing));
+        Output::dim(&format!(
+            "  Skipped {} file(s) already in team repo",
+            skipped_existing
+        ));
     }
 
     if migrated_files.is_empty() {

--- a/src/cli/prompts.rs
+++ b/src/cli/prompts.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use inquire::ui::{Color, RenderConfig, StyleSheet, Styled};
-use inquire::{Confirm, Password, PasswordDisplayMode, Select, Text};
+use inquire::{Confirm, MultiSelect, Password, PasswordDisplayMode, Select, Text};
 
 pub struct Prompt;
 
@@ -43,6 +43,22 @@ impl Prompt {
             .prompt()?;
 
         Ok(options.iter().position(|&x| x == selection).unwrap_or(0))
+    }
+
+    /// Multi-select with default selections. Returns indices of selected options.
+    pub fn multi_select(
+        message: &str,
+        options: Vec<&str>,
+        defaults: &[usize],
+    ) -> Result<Vec<usize>> {
+        let selections = MultiSelect::new(message, options.clone())
+            .with_default(defaults)
+            .prompt()?;
+
+        Ok(selections
+            .iter()
+            .filter_map(|s| options.iter().position(|&x| x == *s))
+            .collect())
     }
 
     pub fn password(message: &str) -> Result<String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Result};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -18,11 +19,22 @@ fn default_config_version() -> u32 {
     1
 }
 
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     /// Config format version - prevents older tether from corrupting newer configs
     #[serde(default = "default_config_version")]
     pub config_version: u32,
+    /// Team-only mode: no personal dotfiles/packages, only team sync
+    /// DEPRECATED: Use features.personal_dotfiles and features.personal_packages instead
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub team_only: bool,
+    /// Feature toggles for what tether should sync
+    #[serde(default)]
+    pub features: FeaturesConfig,
     pub sync: SyncConfig,
     pub backend: BackendConfig,
     pub packages: PackagesConfig,
@@ -37,6 +49,42 @@ pub struct Config {
     pub teams: Option<TeamsConfig>,
     #[serde(default)]
     pub project_configs: ProjectConfigSettings,
+}
+
+/// Feature toggles - what tether should sync
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeaturesConfig {
+    /// Sync personal dotfiles (.zshrc, .gitconfig, etc.)
+    #[serde(default = "default_true")]
+    pub personal_dotfiles: bool,
+
+    /// Sync and upgrade packages (brew, npm, etc.)
+    #[serde(default = "default_true")]
+    pub personal_packages: bool,
+
+    /// Sync team dotfiles (requires team setup)
+    #[serde(default)]
+    pub team_dotfiles: bool,
+
+    /// Share project secrets with collaborators (GitHub write access)
+    #[serde(default)]
+    pub collab_secrets: bool,
+
+    /// Merge team + personal dotfiles (experimental, hidden)
+    #[serde(default)]
+    pub team_layering: bool,
+}
+
+impl Default for FeaturesConfig {
+    fn default() -> Self {
+        Self {
+            personal_dotfiles: true,
+            personal_packages: true,
+            team_dotfiles: false,
+            collab_secrets: false,
+            team_layering: false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -395,6 +443,39 @@ pub struct TeamsConfig {
     /// Allowed GitHub organizations for team repos (empty = no restriction)
     #[serde(default)]
     pub allowed_orgs: Vec<String>,
+    /// Collaborator-based project secret sharing (keyed by collab name)
+    #[serde(default)]
+    pub collabs: HashMap<String, CollabConfig>,
+}
+
+/// Collaborator-based project secret sharing configuration.
+///
+/// Unlike teams which are org-scoped, collabs are repo-scoped.
+/// Collaborators are determined by GitHub write access to the project repo.
+/// One collab repo can serve multiple project repos if they share collaborators.
+///
+/// Security note: Collaborator access is cached locally. Run `tether collab refresh`
+/// to sync with current GitHub permissions. Revoked users retain access until refresh.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CollabConfig {
+    /// Sync repo URL for this collaboration
+    pub sync_url: String,
+    /// Projects sharing secrets via this collab (normalized URLs like github.com/user/repo)
+    #[serde(default)]
+    pub projects: Vec<String>,
+    /// Cache of collaborator GitHub usernames (for display)
+    #[serde(default)]
+    pub members_cache: Vec<String>,
+    /// Last collaborator refresh timestamp
+    #[serde(default)]
+    pub last_refresh: Option<DateTime<Utc>>,
+    /// Whether this collab is enabled
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// Custom deserializer to handle both old (string) and new (array) formats
@@ -549,10 +630,50 @@ impl Config {
             .unwrap_or(false)
     }
 
+    /// Check if any personal features are enabled (dotfiles or packages)
+    pub fn has_personal_features(&self) -> bool {
+        // Legacy team_only flag disables personal features
+        if self.team_only {
+            return false;
+        }
+        self.features.personal_dotfiles || self.features.personal_packages
+    }
+
+    /// Check if any team features are enabled (team dotfiles or collab secrets)
+    pub fn has_team_features(&self) -> bool {
+        self.features.team_dotfiles || self.features.collab_secrets
+    }
+
+    /// Check if personal repo is configured
+    pub fn has_personal_repo(&self) -> bool {
+        !self.backend.url.is_empty()
+    }
+
+    /// Get collab directory for a specific collab name
+    pub fn collab_dir(collab_name: &str) -> Result<PathBuf> {
+        Ok(Self::config_dir()?.join("collabs").join(collab_name))
+    }
+
+    /// Get sync directory for a specific collab
+    pub fn collab_repo_dir(collab_name: &str) -> Result<PathBuf> {
+        Ok(Self::collab_dir(collab_name)?.join("sync"))
+    }
+
+    /// Get collab config for a project (if any)
+    pub fn collab_for_project(&self, normalized_url: &str) -> Option<(String, &CollabConfig)> {
+        let teams = self.teams.as_ref()?;
+        for (name, collab) in &teams.collabs {
+            if collab.enabled && collab.projects.iter().any(|p| p == normalized_url) {
+                return Some((name.clone(), collab));
+            }
+        }
+        None
+    }
+
     pub fn load() -> Result<Self> {
         let path = Self::config_path()?;
         let content = std::fs::read_to_string(path)?;
-        let config: Self = toml::from_str(&content)?;
+        let mut config: Self = toml::from_str(&content)?;
 
         if config.config_version > CURRENT_CONFIG_VERSION {
             bail!(
@@ -561,6 +682,12 @@ impl Config {
                 config.config_version,
                 CURRENT_CONFIG_VERSION
             );
+        }
+
+        // Migrate legacy team_only flag to features
+        if config.team_only {
+            config.features.personal_dotfiles = false;
+            config.features.personal_packages = false;
         }
 
         Ok(config)
@@ -580,6 +707,8 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             config_version: CURRENT_CONFIG_VERSION,
+            team_only: false,
+            features: FeaturesConfig::default(),
             sync: SyncConfig {
                 interval: "5m".to_string(),
                 strategy: ConflictStrategy::LastWriteWins,
@@ -947,5 +1076,80 @@ files = [".zshrc"]
     fn test_config_default_has_current_version() {
         let config = Config::default();
         assert_eq!(config.config_version, CURRENT_CONFIG_VERSION);
+    }
+
+    #[test]
+    fn test_team_only_migration_to_features() {
+        // Legacy config with team_only = true should disable personal features
+        let old_config = r#"
+team_only = true
+
+[sync]
+interval = "5m"
+strategy = "last-write-wins"
+
+[backend]
+type = "git"
+url = ""
+
+[packages.brew]
+enabled = false
+sync_casks = true
+sync_taps = true
+
+[packages.npm]
+enabled = false
+sync_versions = false
+
+[dotfiles]
+files = []
+"#;
+        let mut parsed: Config = toml::from_str(old_config).unwrap();
+
+        // Simulate the migration logic from Config::load()
+        if parsed.team_only {
+            parsed.features.personal_dotfiles = false;
+            parsed.features.personal_packages = false;
+        }
+
+        // Verify migration worked
+        assert!(!parsed.has_personal_features());
+        assert!(!parsed.features.personal_dotfiles);
+        assert!(!parsed.features.personal_packages);
+    }
+
+    #[test]
+    fn test_features_default_enabled() {
+        // Fresh config should have personal features enabled by default
+        let config = Config::default();
+        assert!(config.features.personal_dotfiles);
+        assert!(config.features.personal_packages);
+        assert!(!config.features.team_dotfiles);
+        assert!(!config.features.collab_secrets);
+        assert!(!config.features.team_layering);
+        assert!(config.has_personal_features());
+    }
+
+    #[test]
+    fn test_has_personal_features_respects_legacy_flag() {
+        let mut config = Config::default();
+        assert!(config.has_personal_features());
+
+        // Legacy team_only overrides features
+        config.team_only = true;
+        assert!(!config.has_personal_features());
+    }
+
+    #[test]
+    fn test_has_team_features() {
+        let mut config = Config::default();
+        assert!(!config.has_team_features());
+
+        config.features.team_dotfiles = true;
+        assert!(config.has_team_features());
+
+        config.features.team_dotfiles = false;
+        config.features.collab_secrets = true;
+        assert!(config.has_team_features());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -651,6 +651,15 @@ impl Config {
 
     /// Get collab directory for a specific collab name
     pub fn collab_dir(collab_name: &str) -> Result<PathBuf> {
+        // Defense-in-depth: validate collab name to prevent path traversal
+        if collab_name.is_empty()
+            || collab_name.contains('/')
+            || collab_name.contains('\\')
+            || collab_name.contains("..")
+            || collab_name.starts_with('.')
+        {
+            anyhow::bail!("Invalid collab name: {}", collab_name);
+        }
         Ok(Self::config_dir()?.join("collabs").join(collab_name))
     }
 

--- a/src/sync/packages.rs
+++ b/src/sync/packages.rs
@@ -236,7 +236,11 @@ async fn import_brew(
             formulae: missing_formulae,
             casks: Vec::new(),
         };
-        if brew.import_manifest(&formulae_manifest.generate()).await.is_ok() {
+        if brew
+            .import_manifest(&formulae_manifest.generate())
+            .await
+            .is_ok()
+        {
             installed_any = true;
         }
     }

--- a/src/sync/packages.rs
+++ b/src/sync/packages.rs
@@ -55,6 +55,7 @@ const SIMPLE_MANAGERS: &[PackageManagerDef] = &[
 pub async fn import_packages(
     config: &Config,
     sync_path: &Path,
+    state: &mut SyncState,
     machine_state: &MachineState,
     daemon_mode: bool,
     previously_deferred: &[String],
@@ -68,13 +69,18 @@ pub async fn import_packages(
 
     // Homebrew - special handling for formulae/casks/taps
     if config.packages.brew.enabled {
-        deferred_casks = import_brew(
+        let (casks, installed) = import_brew(
             &manifests_dir,
             machine_state,
             daemon_mode,
             previously_deferred,
         )
         .await;
+        deferred_casks = casks;
+
+        if installed {
+            update_last_upgrade(state, "brew");
+        }
     }
 
     // Simple package managers (npm, pnpm, bun, gem)
@@ -89,35 +95,53 @@ pub async fn import_packages(
         };
 
         if enabled {
-            import_simple_manager(def, &manifests_dir, machine_state).await;
+            let installed = import_simple_manager(def, &manifests_dir, machine_state).await;
+            if installed {
+                update_last_upgrade(state, def.state_key);
+            }
         }
     }
 
     Ok(deferred_casks)
 }
 
+/// Update last_upgrade timestamp for a package manager
+fn update_last_upgrade(state: &mut SyncState, manager: &str) {
+    let now = chrono::Utc::now();
+    state
+        .packages
+        .entry(manager.to_string())
+        .and_modify(|e| e.last_upgrade = Some(now))
+        .or_insert_with(|| crate::sync::state::PackageState {
+            last_sync: now,
+            last_modified: None,
+            last_upgrade: Some(now),
+            hash: String::new(),
+        });
+}
+
 /// Import brew packages (formulae, casks, taps).
 /// Casks are installed individually to detect which need password.
-/// Returns list of casks that need password (flagged for manual sync).
+/// Returns (deferred_casks, installed_any) - list of casks needing password and whether any packages were installed.
 async fn import_brew(
     manifests_dir: &Path,
     machine_state: &MachineState,
     daemon_mode: bool,
     previously_deferred: &[String],
-) -> Vec<String> {
+) -> (Vec<String>, bool) {
     let brewfile = manifests_dir.join("Brewfile");
     if !brewfile.exists() {
-        return Vec::new();
+        return (Vec::new(), false);
     }
 
     let brew = BrewManager::new();
     if !brew.is_available().await {
-        return Vec::new();
+        return (Vec::new(), false);
     }
 
     let manifest = match std::fs::read_to_string(&brewfile) {
         Ok(m) => m,
-        Err(_) => return Vec::new(),
+        Err(_) => return (Vec::new(), false),
     };
 
     // Parse the Brewfile
@@ -183,6 +207,8 @@ async fn import_brew(
         }
     }
 
+    let mut installed_any = false;
+
     // Install formulae via bundle (no password needed)
     if !missing_formulae.is_empty() {
         Output::info(&format!(
@@ -210,8 +236,8 @@ async fn import_brew(
             formulae: missing_formulae,
             casks: Vec::new(),
         };
-        if let Err(e) = brew.import_manifest(&formulae_manifest.generate()).await {
-            Output::warning(&format!("Failed to import formulae: {}", e));
+        if brew.import_manifest(&formulae_manifest.generate()).await.is_ok() {
+            installed_any = true;
         }
     }
 
@@ -231,7 +257,9 @@ async fn import_brew(
 
         for cask in &casks_to_try {
             match brew.install_cask(cask, !daemon_mode).await {
-                Ok(true) => {} // installed successfully
+                Ok(true) => {
+                    installed_any = true;
+                }
                 Ok(false) => {
                     if daemon_mode {
                         // Daemon: needs password - flag for manual sync
@@ -252,18 +280,19 @@ async fn import_brew(
         }
     }
 
-    flagged_casks
+    (flagged_casks, installed_any)
 }
 
 /// Import a simple package manager (one package per line manifest)
+/// Returns true if any packages were installed.
 async fn import_simple_manager(
     def: &PackageManagerDef,
     manifests_dir: &Path,
     machine_state: &MachineState,
-) {
+) -> bool {
     let manifest_path = manifests_dir.join(def.manifest_file);
     if !manifest_path.exists() {
-        return;
+        return false;
     }
 
     // Get the appropriate manager
@@ -273,16 +302,16 @@ async fn import_simple_manager(
         "bun" => Box::new(BunManager::new()),
         "gem" => Box::new(GemManager::new()),
         "uv" => Box::new(UvManager::new()),
-        _ => return,
+        _ => return false,
     };
 
     if !manager.is_available().await {
-        return;
+        return false;
     }
 
     let manifest = match std::fs::read_to_string(&manifest_path) {
         Ok(m) => m,
-        Err(_) => return,
+        Err(_) => return false,
     };
 
     let local_packages: HashSet<_> = machine_state
@@ -308,7 +337,7 @@ async fn import_simple_manager(
         .collect();
 
     if missing.is_empty() {
-        return;
+        return false;
     }
 
     Output::info(&format!(
@@ -320,12 +349,16 @@ async fn import_simple_manager(
 
     let filtered_manifest = missing.join("\n") + "\n";
 
-    if let Err(e) = manager.import_manifest(&filtered_manifest).await {
-        Output::warning(&format!(
-            "Failed to import {}: {}",
-            manifest_path.display(),
-            e
-        ));
+    match manager.import_manifest(&filtered_manifest).await {
+        Ok(_) => true,
+        Err(e) => {
+            Output::warning(&format!(
+                "Failed to import {}: {}",
+                manifest_path.display(),
+                e
+            ));
+            false
+        }
     }
 }
 
@@ -407,12 +440,24 @@ fn sync_brew(
         .map(|c| format!("{:x}", Sha256::digest(&c)));
     let changed = file_hash.as_ref() != Some(&hash);
 
-    if changed && !dry_run {
-        std::fs::write(&manifest_path, &manifest)?;
+    if !dry_run {
+        let now = chrono::Utc::now();
+        let existing = state.packages.get("brew");
+
+        if changed {
+            std::fs::write(&manifest_path, &manifest)?;
+        }
+
         state.packages.insert(
             "brew".to_string(),
             PackageState {
-                last_sync: chrono::Utc::now(),
+                last_sync: now,
+                last_modified: if changed {
+                    Some(now)
+                } else {
+                    existing.and_then(|e| e.last_modified)
+                },
+                last_upgrade: existing.and_then(|e| e.last_upgrade),
                 hash,
             },
         );
@@ -446,12 +491,24 @@ fn sync_simple_manager(
         .map(|c| format!("{:x}", Sha256::digest(&c)));
     let changed = file_hash.as_ref() != Some(&hash);
 
-    if changed && !dry_run {
-        std::fs::write(&manifest_path, &manifest)?;
+    if !dry_run {
+        let now = chrono::Utc::now();
+        let existing = state.packages.get(def.state_key);
+
+        if changed {
+            std::fs::write(&manifest_path, &manifest)?;
+        }
+
         state.packages.insert(
             def.state_key.to_string(),
             PackageState {
-                last_sync: chrono::Utc::now(),
+                last_sync: now,
+                last_modified: if changed {
+                    Some(now)
+                } else {
+                    existing.and_then(|e| e.last_modified)
+                },
+                last_upgrade: existing.and_then(|e| e.last_upgrade),
                 hash,
             },
         );

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -31,7 +31,14 @@ pub struct FileState {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PackageState {
+    /// When we last checked/synced this package manager
     pub last_sync: DateTime<Utc>,
+    /// When the manifest content last changed
+    #[serde(default)]
+    pub last_modified: Option<DateTime<Utc>>,
+    /// When packages were last installed/upgraded
+    #[serde(default)]
+    pub last_upgrade: Option<DateTime<Utc>>,
     pub hash: String,
 }
 

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -464,4 +464,34 @@ mod tests {
         let result = MachineState::load_from_repo(temp.path(), "nonexistent").unwrap();
         assert!(result.is_none());
     }
+
+    #[test]
+    fn test_package_state_timestamps_roundtrip() {
+        let now = Utc::now();
+        let state = PackageState {
+            last_sync: now,
+            last_modified: Some(now),
+            last_upgrade: Some(now),
+            hash: "abc123".to_string(),
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        let loaded: PackageState = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(loaded.last_sync, state.last_sync);
+        assert_eq!(loaded.last_modified, state.last_modified);
+        assert_eq!(loaded.last_upgrade, state.last_upgrade);
+        assert_eq!(loaded.hash, state.hash);
+    }
+
+    #[test]
+    fn test_package_state_missing_timestamps_defaults() {
+        // Simulate old JSON without last_modified/last_upgrade fields
+        let old_json = r#"{"last_sync":"2024-01-01T00:00:00Z","hash":"abc123"}"#;
+        let loaded: PackageState = serde_json::from_str(old_json).unwrap();
+
+        assert!(loaded.last_modified.is_none());
+        assert!(loaded.last_upgrade.is_none());
+        assert_eq!(loaded.hash, "abc123");
+    }
 }


### PR DESCRIPTION
## Summary

- Add explicit feature toggles replacing implicit `team_only` behavior
- Add GitHub collaborator-based project secrets (`tether collab` commands)
- Add feature selection during `tether init`
- Add `tether config features` subcommand

## Features

| Feature | Description | Default |
|---------|-------------|---------|
| `personal_dotfiles` | Sync shell configs (.zshrc, .gitconfig) | enabled |
| `personal_packages` | Sync packages (brew, npm, etc.) | enabled |
| `team_dotfiles` | Sync org-based team dotfiles | disabled |
| `collab_secrets` | Share project secrets with GitHub collaborators | disabled |
| `team_layering` | Merge team + personal dotfiles (experimental) | disabled |

## New Commands

```bash
# Feature management
tether config features              # List features
tether config features enable <f>   # Enable a feature
tether config features disable <f>  # Disable a feature

# Collab secrets (GitHub collaborator-based)
tether collab init                  # Initialize collab for project
tether collab join <url>            # Join existing collab
tether collab add <file>            # Add encrypted secret
tether collab refresh               # Refresh collaborator list
tether collab status                # Show collab status
```

## Breaking Changes

- `is_team_only()` renamed to `has_personal_features()` (inverted logic)
- Legacy `team_only` config field deprecated (still works via migration)

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (127 tests)
- [x] `cargo build --release` succeeds
- [ ] Manual test: `tether init` with feature selection
- [ ] Manual test: `tether config features` commands
- [ ] Manual test: `tether collab` workflow