### PR TITLE
feat: Windows platform support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ env:
 
 jobs:
   test:
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ env:
   SIGNING_IDENTITY: "Developer ID Application: Paddo Tech PTY LTD (D9Q57P9D3L)"
 
 jobs:
-  build:
+  build-macos:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -77,14 +77,62 @@ jobs:
 
       - name: Package binaries
         run: |
+          mkdir -p dist
+
           cd target/aarch64-apple-darwin/release
           tar -czf tether-aarch64-apple-darwin.tar.gz tether
           shasum -a 256 tether-aarch64-apple-darwin.tar.gz > tether-aarch64-apple-darwin.tar.gz.sha256
+          cp tether-aarch64-apple-darwin.tar.gz tether-aarch64-apple-darwin.tar.gz.sha256 ../../../dist/
           cd -
 
           cd target/x86_64-apple-darwin/release
           tar -czf tether-x86_64-apple-darwin.tar.gz tether
           shasum -a 256 tether-x86_64-apple-darwin.tar.gz > tether-x86_64-apple-darwin.tar.gz.sha256
+          cp tether-x86_64-apple-darwin.tar.gz tether-x86_64-apple-darwin.tar.gz.sha256 ../../../dist/
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-binaries
+          path: dist/
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build release
+        run: cargo build --release
+
+      - name: Package binary
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist
+          cd target/release
+          Compress-Archive -Path tether.exe -DestinationPath tether-x86_64-pc-windows-msvc.zip
+          $hash = (Get-FileHash tether-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower()
+          "$hash  tether-x86_64-pc-windows-msvc.zip" | Out-File -NoNewline -Encoding ascii tether-x86_64-pc-windows-msvc.zip.sha256
+          Copy-Item tether-x86_64-pc-windows-msvc.zip, tether-x86_64-pc-windows-msvc.zip.sha256 ../../dist/
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-binary
+          path: dist/
+
+  release:
+    needs: [build-macos, build-windows]
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
 
       - name: Get version from Cargo.toml
         id: version
@@ -129,10 +177,12 @@ jobs:
           prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
           generate_release_notes: true
           files: |
-            target/aarch64-apple-darwin/release/tether-aarch64-apple-darwin.tar.gz
-            target/aarch64-apple-darwin/release/tether-aarch64-apple-darwin.tar.gz.sha256
-            target/x86_64-apple-darwin/release/tether-x86_64-apple-darwin.tar.gz
-            target/x86_64-apple-darwin/release/tether-x86_64-apple-darwin.tar.gz.sha256
+            artifacts/macos-binaries/tether-aarch64-apple-darwin.tar.gz
+            artifacts/macos-binaries/tether-aarch64-apple-darwin.tar.gz.sha256
+            artifacts/macos-binaries/tether-x86_64-apple-darwin.tar.gz
+            artifacts/macos-binaries/tether-x86_64-apple-darwin.tar.gz.sha256
+            artifacts/windows-binary/tether-x86_64-pc-windows-msvc.zip
+            artifacts/windows-binary/tether-x86_64-pc-windows-msvc.zip.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -143,8 +193,8 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           IS_PRERELEASE: ${{ steps.version.outputs.prerelease }}
         run: |
-          SHA_ARM=$(cat target/aarch64-apple-darwin/release/tether-aarch64-apple-darwin.tar.gz.sha256 | awk '{print $1}')
-          SHA_X86=$(cat target/x86_64-apple-darwin/release/tether-x86_64-apple-darwin.tar.gz.sha256 | awk '{print $1}')
+          SHA_ARM=$(cat artifacts/macos-binaries/tether-aarch64-apple-darwin.tar.gz.sha256 | awk '{print $1}')
+          SHA_X86=$(cat artifacts/macos-binaries/tether-x86_64-apple-darwin.tar.gz.sha256 | awk '{print $1}')
 
           # Clone the tap repo
           rm -rf /tmp/homebrew-tap
@@ -207,4 +257,3 @@ jobs:
           git add "$FORMULA_FILE"
           git commit -m "tether-cli ${VERSION}"
           git push
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Windows platform support with winget package manager
+- Cross-platform package mapping for dotfile sync across macOS/Linux/Windows
+- Windows daemon scheduling via Task Scheduler
+- Windows secrets file permissions via `icacls`
+- Symlink fallback to file copy when Windows privileges unavailable
+- Cross-platform path normalization (forward slashes in sync state)
+- Windows CI test matrix and release builds (`.zip` + SHA256)
+
 ## [1.9.0] - 2026-02-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,6 @@ which = "6.0"
 log = "0.4"
 env_logger = "0.11"
 
-# IPC for daemon
-interprocess = "2.0"
-
 # Async trait
 async-trait = "0.1"
 
@@ -83,8 +80,7 @@ glob = "0.3"
 # Text diffing
 similar = "2.6"
 
-# System signals
-libc = "0.2"
+# Temp files
 tempfile = "3.8"
 
 # File locking
@@ -93,6 +89,10 @@ fs2 = "0.4"
 # TUI dashboard
 ratatui = "0.29"
 crossterm = "0.28"
+
+# System signals (Unix only)
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/WINDOWS_SUPPORT.md
+++ b/WINDOWS_SUPPORT.md
@@ -1,0 +1,41 @@
+# Windows Support
+
+## What works
+
+- **Dotfile sync** — Push/pull encrypted dotfiles, `.gitconfig` syncs via `~/.gitconfig` (`%USERPROFILE%\.gitconfig`)
+- **Package management** — WinGet integration: list, install, uninstall, upgrade, export/import manifests
+- **Daemon** — Background sync via Task Scheduler (`schtasks`), RestartOnFailure for auto-restart
+- **Project configs** — Sync project-level configs with symlink support (falls back to copy without Developer Mode)
+- **Team sync** — Symlinks for team configs, copy fallback on Windows
+- **Notifications** — PowerShell toast notifications for sync conflicts
+- **CI** — `macos-latest` + `windows-latest` matrix
+- **Release** — Signed macOS binaries + Windows `.zip` with SHA256
+
+## Platform behavior differences
+
+| Feature | macOS | Windows |
+|---------|-------|---------|
+| Daemon install | launchd (KeepAlive) | Task Scheduler (RestartOnFailure) |
+| Symlinks | Native | Requires Developer Mode; copies as fallback |
+| Notifications | AppleScript | PowerShell toast |
+| Default merge tool | `opendiff` | `code` (VS Code) |
+| Default editor | `nano` | `notepad` |
+| File permissions | `0o600` for secrets | Standard ACL (no restriction) |
+| Process management | `kill`/signals | `tasklist`/`taskkill` |
+| Package manager | Homebrew | WinGet |
+
+## Architecture notes
+
+- Package managers check `is_available()` at runtime — brew returns false on Windows, winget returns false on macOS
+- Default dotfiles (`.zshrc`, `.bashrc`) have `create_if_missing: false` so they won't be created on Windows
+- Config dir is `~/.tether/` → `C:\Users\<name>\.tether\` via the `home` crate
+- State keys use forward slashes on all platforms (normalized with `.replace('\\', "/")`)
+- Path validation rejects `..`, `/`, `\`, and drive letters (`C:\`) for traversal safety
+- `create_symlink()` in `sync/mod.rs` handles the Developer Mode fallback centrally
+
+## Known limitations
+
+- No ARM64 Windows build (x86_64 runs under emulation)
+- Cached encryption key (`~/.tether/key.cache`) uses default file permissions on Windows
+- `winget list` parser uses fixed-width column positions — may break with CJK package names or non-English locales
+- No WinGet manifest in release pipeline (users install from GitHub releases)

--- a/WINDOWS_SUPPORT.md
+++ b/WINDOWS_SUPPORT.md
@@ -8,7 +8,7 @@
 - **Project configs** — Sync project-level configs with symlink support (falls back to copy without Developer Mode)
 - **Team sync** — Symlinks for team configs, copy fallback on Windows
 - **Notifications** — PowerShell toast notifications for sync conflicts
-- **CI** — `macos-latest` + `windows-latest` matrix
+- **CI** — `ubuntu-latest` + `macos-latest` + `windows-latest` matrix
 - **Release** — Signed macOS binaries + Windows `.zip` with SHA256
 
 ## Platform behavior differences
@@ -20,8 +20,8 @@
 | Notifications | AppleScript | PowerShell toast |
 | Default merge tool | `opendiff` | `code` (VS Code) |
 | Default editor | `nano` | `notepad` |
-| File permissions | `0o600` for secrets | Standard ACL (no restriction) |
-| Process management | `kill`/signals | `tasklist`/`taskkill` |
+| File permissions | `0o600` for secrets | ACL restricted via `icacls` |
+| Process management | `kill`/signals (graceful SIGTERM) | `tasklist`/`taskkill` (force kill only) |
 | Package manager | Homebrew | WinGet |
 
 ## Architecture notes
@@ -36,6 +36,5 @@
 ## Known limitations
 
 - No ARM64 Windows build (x86_64 runs under emulation)
-- Cached encryption key (`~/.tether/key.cache`) uses default file permissions on Windows
-- `winget list` parser uses fixed-width column positions — may break with CJK package names or non-English locales
+- `winget list` parser uses fixed-width column positions — handles CJK double-width characters but may break with non-English locales (different header text)
 - No WinGet manifest in release pipeline (users install from GitHub releases)

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -115,6 +115,8 @@ pub async fn edit() -> Result<()> {
     let editor = std::env::var("EDITOR").unwrap_or_else(|_| {
         if cfg!(target_os = "macos") {
             "nano".to_string()
+        } else if cfg!(target_os = "windows") {
+            "notepad".to_string()
         } else {
             "vi".to_string()
         }

--- a/src/cli/commands/daemon.rs
+++ b/src/cli/commands/daemon.rs
@@ -272,7 +272,7 @@ fn generate_plist() -> Result<String> {
 }
 
 pub async fn install() -> Result<()> {
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     {
         if let Some(pid) = read_daemon_pid()? {
             if is_process_running(pid) {
@@ -405,7 +405,7 @@ pub async fn install() -> Result<()> {
 }
 
 pub async fn uninstall() -> Result<()> {
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     {
         let output = Command::new("schtasks")
             .args(["/Delete", "/TN", "TetherDaemon", "/F"])

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -271,7 +271,14 @@ async fn setup_github_automatic() -> Result<String> {
     if !GitHubCli::is_installed() {
         Output::warning("GitHub CLI (gh) is not installed");
 
-        if Prompt::confirm("Install GitHub CLI via Homebrew?", true)? {
+        let install_method = if cfg!(target_os = "macos") {
+            "Homebrew"
+        } else if cfg!(target_os = "windows") {
+            "winget"
+        } else {
+            "package manager"
+        };
+        if Prompt::confirm(&format!("Install GitHub CLI via {install_method}?"), true)? {
             let pb = Progress::spinner("Installing GitHub CLI...");
             GitHubCli::install().await?;
             Progress::finish_success(&pb, "GitHub CLI installed");

--- a/src/cli/commands/packages.rs
+++ b/src/cli/commands/packages.rs
@@ -4,7 +4,7 @@ use crate::cli::output::Output;
 use crate::cli::prompts::Prompt;
 use crate::packages::{
     BrewManager, BunManager, GemManager, NpmManager, PackageInfo, PackageManager, PnpmManager,
-    UvManager,
+    UvManager, WingetManager,
 };
 
 struct PackageEntry {
@@ -27,6 +27,7 @@ pub async fn run(list_only: bool, yes: bool) -> Result<()> {
         Box::new(BunManager::new()),
         Box::new(GemManager::new()),
         Box::new(UvManager::new()),
+        Box::new(WingetManager::new()),
     ];
 
     // Collect packages grouped by manager

--- a/src/cli/commands/upgrade.rs
+++ b/src/cli/commands/upgrade.rs
@@ -1,7 +1,7 @@
 use crate::cli::output::Output;
 use crate::packages::{
     brew::BrewManager, bun::BunManager, gem::GemManager, manager::PackageManager, npm::NpmManager,
-    pnpm::PnpmManager, uv::UvManager,
+    pnpm::PnpmManager, uv::UvManager, winget::WingetManager,
 };
 use crate::sync::SyncState;
 use anyhow::Result;
@@ -17,6 +17,7 @@ pub async fn run() -> Result<()> {
         Box::new(BunManager::new()),
         Box::new(GemManager::new()),
         Box::new(UvManager::new()),
+        Box::new(WingetManager::new()),
     ];
 
     // Determine which managers are available and have packages

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1,3 +1,4 @@
+pub mod pid;
 pub mod server;
 
 pub use server::{is_daemon_mode, DaemonServer};

--- a/src/daemon/pid.rs
+++ b/src/daemon/pid.rs
@@ -1,0 +1,41 @@
+use crate::config::Config;
+use anyhow::Result;
+
+pub fn read_daemon_pid() -> Result<Option<u32>> {
+    let pid_path = Config::config_dir()?.join("daemon.pid");
+    if !pid_path.exists() {
+        return Ok(None);
+    }
+
+    let contents = std::fs::read_to_string(&pid_path)?;
+    match contents.trim().parse::<u32>() {
+        Ok(pid) if pid > 0 => Ok(Some(pid)),
+        _ => Ok(None),
+    }
+}
+
+#[cfg(unix)]
+pub fn is_process_running(pid: u32) -> bool {
+    unsafe {
+        if libc::kill(pid as libc::pid_t, 0) == 0 {
+            true
+        } else {
+            let err = std::io::Error::last_os_error();
+            err.kind() != std::io::ErrorKind::NotFound
+        }
+    }
+}
+
+#[cfg(windows)]
+pub fn is_process_running(pid: u32) -> bool {
+    use std::process::Command;
+    Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
+        .output()
+        .map(|o| {
+            let out = String::from_utf8_lossy(&o.stdout);
+            // CSV format quotes the PID: "name","1234",... — exact match avoids substring false positives
+            out.contains(&format!("\"{pid}\""))
+        })
+        .unwrap_or(false)
+}

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -731,22 +731,6 @@ impl DaemonServer {
             }
         }
 
-        if config.packages.uv.enabled {
-            let uv = crate::packages::UvManager::new();
-            if uv.is_available().await {
-                log::info!("Updating uv packages...");
-                let hash_before = uv.compute_manifest_hash().await.ok();
-                if let Err(e) = uv.update_all().await {
-                    log::error!("uv update failed: {}", e);
-                } else {
-                    let hash_after = uv.compute_manifest_hash().await.ok();
-                    if hash_before != hash_after {
-                        any_actual_updates = true;
-                    }
-                }
-            }
-        }
-
         if config.packages.winget.enabled {
             let winget = WingetManager::new();
             if winget.is_available().await {

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -713,6 +713,10 @@ impl DaemonServer {
             (Box::new(BunManager::new()), config.packages.bun.enabled),
             (Box::new(GemManager::new()), config.packages.gem.enabled),
             (Box::new(UvManager::new()), config.packages.uv.enabled),
+            (
+                Box::new(WingetManager::new()),
+                config.packages.winget.enabled,
+            ),
         ];
 
         for (manager, enabled) in &managers {
@@ -727,22 +731,6 @@ impl DaemonServer {
                 let hash_after = manager.compute_manifest_hash().await.ok();
                 if hash_before != hash_after {
                     any_actual_updates = true;
-                }
-            }
-        }
-
-        if config.packages.winget.enabled {
-            let winget = WingetManager::new();
-            if winget.is_available().await {
-                log::info!("Updating winget packages...");
-                let hash_before = winget.compute_manifest_hash().await.ok();
-                if let Err(e) = winget.update_all().await {
-                    log::error!("winget update failed: {}", e);
-                } else {
-                    let hash_after = winget.compute_manifest_hash().await.ok();
-                    if hash_before != hash_after {
-                        any_actual_updates = true;
-                    }
                 }
             }
         }

--- a/src/dashboard/config_edit.rs
+++ b/src/dashboard/config_edit.rs
@@ -173,6 +173,12 @@ static FIELDS: LazyLock<Vec<ConfigField>> = LazyLock::new(|| {
             section: "Packages",
             kind: FieldKind::Bool,
         },
+        ConfigField {
+            key: "winget.enabled",
+            label: "Winget enabled",
+            section: "Packages",
+            kind: FieldKind::Bool,
+        },
         // Project
         ConfigField {
             key: "project_configs.enabled",
@@ -236,6 +242,7 @@ pub fn get_value(config: &Config, idx: usize) -> String {
         "gem.sync_versions" => config.packages.gem.sync_versions.to_string(),
         "uv.enabled" => config.packages.uv.enabled.to_string(),
         "uv.sync_versions" => config.packages.uv.sync_versions.to_string(),
+        "winget.enabled" => config.packages.winget.enabled.to_string(),
         // Project
         "project_configs.enabled" => config.project_configs.enabled.to_string(),
         "project_configs.search_paths" => {
@@ -306,6 +313,7 @@ pub fn toggle(config: &mut Config, idx: usize) -> bool {
         }
         "uv.enabled" => config.packages.uv.enabled = !config.packages.uv.enabled,
         "uv.sync_versions" => config.packages.uv.sync_versions = !config.packages.uv.sync_versions,
+        "winget.enabled" => config.packages.winget.enabled = !config.packages.winget.enabled,
         "project_configs.enabled" => {
             config.project_configs.enabled = !config.project_configs.enabled
         }

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -696,6 +696,7 @@ async fn run_uninstall(manager_key: &str, package: &str) -> std::result::Result<
         "bun" => Box::new(BunManager),
         "gem" => Box::new(GemManager),
         "uv" => Box::new(UvManager),
+        "winget" => Box::new(WingetManager),
         _ => return Err(format!("Unknown manager: {}", manager_key)),
     };
 

--- a/src/dashboard/state.rs
+++ b/src/dashboard/state.rs
@@ -57,7 +57,7 @@ impl DashboardState {
 
         match contents.trim().parse::<u32>() {
             Ok(pid) if pid > 0 => {
-                let running = unsafe { libc::kill(pid as libc::pid_t, 0) == 0 };
+                let running = crate::daemon::pid::is_process_running(pid);
                 (Some(pid), running)
             }
             _ => (None, false),

--- a/src/dashboard/widgets/mod.rs
+++ b/src/dashboard/widgets/mod.rs
@@ -17,6 +17,7 @@ pub fn manager_label(key: &str) -> &str {
         "bun" => "Bun",
         "gem" => "Gem",
         "uv" => "uv",
+        "winget" => "Winget",
         _ => key,
     }
 }

--- a/src/packages/brew.rs
+++ b/src/packages/brew.rs
@@ -86,7 +86,7 @@ impl BrewManager {
                 let requested_version = &formula[at_pos + 1..];
 
                 // Check what versions of this formula are installed
-                let output = Command::new("brew")
+                let output = Command::new(super::resolve_program("brew"))
                     .args(["list", "--versions"])
                     .output()
                     .await?;
@@ -106,7 +106,7 @@ impl BrewManager {
                                 if installed_base == base_name
                                     && installed_version != requested_version
                                 {
-                                    let _ = Command::new("brew")
+                                    let _ = Command::new(super::resolve_program("brew"))
                                         .args(["unlink", installed_name])
                                         .output()
                                         .await;
@@ -122,7 +122,10 @@ impl BrewManager {
     }
 
     async fn run_brew(&self, args: &[&str]) -> Result<String> {
-        let output = Command::new("brew").args(args).output().await?;
+        let output = Command::new(super::resolve_program("brew"))
+            .args(args)
+            .output()
+            .await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -169,7 +172,7 @@ impl BrewManager {
     pub async fn install_cask(&self, cask: &str, allow_interactive: bool) -> Result<bool> {
         use std::process::Stdio;
 
-        let mut cmd = Command::new("brew");
+        let mut cmd = Command::new(super::resolve_program("brew"));
         cmd.args(["install", "--cask", cask])
             .env("NONINTERACTIVE", "1")
             .env("HOMEBREW_NO_AUTO_UPDATE", "1");
@@ -268,7 +271,7 @@ impl PackageManager for BrewManager {
         }
 
         // Generate Brewfile
-        let output = Command::new("brew")
+        let output = Command::new(super::resolve_program("brew"))
             .args([
                 "bundle",
                 "dump",
@@ -313,7 +316,7 @@ impl PackageManager for BrewManager {
         // Use `brew bundle install` to install packages from Brewfile
         // --no-upgrade: don't upgrade existing packages (faster, less disruptive)
         // Stream output to terminal so user can see progress and any errors
-        let status = Command::new("brew")
+        let status = Command::new(super::resolve_program("brew"))
             .args([
                 "bundle",
                 "install",
@@ -367,7 +370,7 @@ impl PackageManager for BrewManager {
         // Remove packages not in manifest
         for pkg in installed {
             if !desired.contains(pkg.name.as_str()) {
-                let output = Command::new("brew")
+                let output = Command::new(super::resolve_program("brew"))
                     .args(["uninstall", &pkg.name])
                     .output()
                     .await?;
@@ -390,9 +393,15 @@ impl PackageManager for BrewManager {
         }
 
         // Update Homebrew itself and upgrade all packages
-        Command::new("brew").args(["update"]).output().await?;
+        Command::new(super::resolve_program("brew"))
+            .args(["update"])
+            .output()
+            .await?;
 
-        let output = Command::new("brew").args(["upgrade"]).output().await?;
+        let output = Command::new(super::resolve_program("brew"))
+            .args(["upgrade"])
+            .output()
+            .await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -403,7 +412,7 @@ impl PackageManager for BrewManager {
     }
 
     async fn uninstall(&self, package: &str) -> Result<()> {
-        let output = Command::new("brew")
+        let output = Command::new(super::resolve_program("brew"))
             .args(["uninstall", package])
             .output()
             .await?;
@@ -417,7 +426,7 @@ impl PackageManager for BrewManager {
     }
 
     async fn get_dependents(&self, package: &str) -> Result<Vec<String>> {
-        let output = Command::new("brew")
+        let output = Command::new(super::resolve_program("brew"))
             .args(["uses", "--installed", package])
             .output()
             .await?;

--- a/src/packages/bun.rs
+++ b/src/packages/bun.rs
@@ -22,7 +22,10 @@ impl BunManager {
     }
 
     async fn run_bun(&self, args: &[&str]) -> Result<String> {
-        let output = Command::new("bun").args(args).output().await?;
+        let output = Command::new(super::resolve_program("bun"))
+            .args(args)
+            .output()
+            .await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -126,7 +129,7 @@ impl PackageManager for BunManager {
         // bun update -g is broken (only updates first package)
         // Workaround: reinstall each package to get latest version
         for pkg in packages {
-            let output = Command::new("bun")
+            let output = Command::new(super::resolve_program("bun"))
                 .args(["add", "-g", &pkg.name])
                 .output()
                 .await?;
@@ -141,7 +144,7 @@ impl PackageManager for BunManager {
     }
 
     async fn uninstall(&self, package: &str) -> Result<()> {
-        let output = Command::new("bun")
+        let output = Command::new(super::resolve_program("bun"))
             .args(["remove", "-g", package])
             .output()
             .await?;

--- a/src/packages/gem.rs
+++ b/src/packages/gem.rs
@@ -11,7 +11,10 @@ impl GemManager {
     }
 
     async fn run_gem(&self, args: &[&str]) -> Result<String> {
-        let output = Command::new("gem").args(args).output().await?;
+        let output = Command::new(super::resolve_program("gem"))
+            .args(args)
+            .output()
+            .await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -86,7 +89,7 @@ impl PackageManager for GemManager {
             return Ok(());
         }
 
-        let output = Command::new("gem")
+        let output = Command::new(super::resolve_program("gem"))
             .args(["update", "--user-install"])
             .output()
             .await?;
@@ -100,7 +103,7 @@ impl PackageManager for GemManager {
     }
 
     async fn uninstall(&self, package: &str) -> Result<()> {
-        let output = Command::new("gem")
+        let output = Command::new(super::resolve_program("gem"))
             .args(["uninstall", package, "-x", "-a"])
             .output()
             .await?;
@@ -115,7 +118,7 @@ impl PackageManager for GemManager {
 
     async fn get_dependents(&self, package: &str) -> Result<Vec<String>> {
         // gem dependency -R shows reverse dependencies
-        let output = Command::new("gem")
+        let output = Command::new(super::resolve_program("gem"))
             .args(["dependency", "-R", package])
             .output()
             .await?;

--- a/src/packages/mapping.rs
+++ b/src/packages/mapping.rs
@@ -1,0 +1,368 @@
+use std::collections::HashMap;
+
+pub struct PackageMapping {
+    pub brew_formula: Option<&'static str>,
+    pub brew_cask: Option<&'static str>,
+    pub winget: Option<&'static str>,
+}
+
+/// Built-in cross-platform package mappings.
+fn default_mappings() -> Vec<PackageMapping> {
+    vec![
+        // CLI tools
+        PackageMapping {
+            brew_formula: Some("git"),
+            brew_cask: None,
+            winget: Some("Git.Git"),
+        },
+        PackageMapping {
+            brew_formula: Some("curl"),
+            brew_cask: None,
+            winget: Some("cURL.cURL"),
+        },
+        PackageMapping {
+            brew_formula: Some("wget"),
+            brew_cask: None,
+            winget: Some("JernejSimoncic.Wget"),
+        },
+        PackageMapping {
+            brew_formula: Some("jq"),
+            brew_cask: None,
+            winget: Some("jqlang.jq"),
+        },
+        PackageMapping {
+            brew_formula: Some("gh"),
+            brew_cask: None,
+            winget: Some("GitHub.cli"),
+        },
+        PackageMapping {
+            brew_formula: Some("ripgrep"),
+            brew_cask: None,
+            winget: Some("BurntSushi.ripgrep.MSVC"),
+        },
+        PackageMapping {
+            brew_formula: Some("fd"),
+            brew_cask: None,
+            winget: Some("sharkdp.fd"),
+        },
+        PackageMapping {
+            brew_formula: Some("bat"),
+            brew_cask: None,
+            winget: Some("sharkdp.bat"),
+        },
+        PackageMapping {
+            brew_formula: Some("fzf"),
+            brew_cask: None,
+            winget: Some("junegunn.fzf"),
+        },
+        PackageMapping {
+            brew_formula: Some("tree"),
+            brew_cask: None,
+            winget: Some("IDRIX.Tree"),
+        },
+        PackageMapping {
+            brew_formula: Some("cmake"),
+            brew_cask: None,
+            winget: Some("Kitware.CMake"),
+        },
+        // Languages & runtimes
+        PackageMapping {
+            brew_formula: Some("node"),
+            brew_cask: None,
+            winget: Some("OpenJS.NodeJS.LTS"),
+        },
+        PackageMapping {
+            brew_formula: Some("python"),
+            brew_cask: None,
+            winget: Some("Python.Python.3"),
+        },
+        PackageMapping {
+            brew_formula: Some("go"),
+            brew_cask: None,
+            winget: Some("GoLang.Go"),
+        },
+        PackageMapping {
+            brew_formula: Some("rustup"),
+            brew_cask: None,
+            winget: Some("Rustlang.Rustup"),
+        },
+        // Cask ↔ winget (GUI apps)
+        PackageMapping {
+            brew_formula: None,
+            brew_cask: Some("docker"),
+            winget: Some("Docker.DockerDesktop"),
+        },
+        PackageMapping {
+            brew_formula: None,
+            brew_cask: Some("firefox"),
+            winget: Some("Mozilla.Firefox"),
+        },
+        PackageMapping {
+            brew_formula: None,
+            brew_cask: Some("google-chrome"),
+            winget: Some("Google.Chrome"),
+        },
+        PackageMapping {
+            brew_formula: None,
+            brew_cask: Some("visual-studio-code"),
+            winget: Some("Microsoft.VisualStudioCode"),
+        },
+        PackageMapping {
+            brew_formula: None,
+            brew_cask: Some("slack"),
+            winget: Some("SlackTechnologies.Slack"),
+        },
+        PackageMapping {
+            brew_formula: None,
+            brew_cask: Some("discord"),
+            winget: Some("Discord.Discord"),
+        },
+        PackageMapping {
+            brew_formula: None,
+            brew_cask: Some("spotify"),
+            winget: Some("Spotify.Spotify"),
+        },
+        PackageMapping {
+            brew_formula: None,
+            brew_cask: Some("1password"),
+            winget: Some("AgileBits.1Password"),
+        },
+        PackageMapping {
+            brew_formula: None,
+            brew_cask: Some("notion"),
+            winget: Some("Notion.Notion"),
+        },
+        PackageMapping {
+            brew_formula: None,
+            brew_cask: Some("obsidian"),
+            winget: Some("Obsidian.Obsidian"),
+        },
+        PackageMapping {
+            brew_formula: None,
+            brew_cask: Some("figma"),
+            winget: Some("Figma.Figma"),
+        },
+        PackageMapping {
+            brew_formula: None,
+            brew_cask: Some("postman"),
+            winget: Some("Postman.Postman"),
+        },
+    ]
+}
+
+/// Config-level mapping entry (user overrides).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MappingEntry {
+    pub brew: Option<String>,
+    pub cask: Option<String>,
+    pub winget: Option<String>,
+}
+
+/// Resolved lookup tables built from defaults + config overrides.
+pub struct MappingTable {
+    brew_formula_to_winget: HashMap<String, String>,
+    brew_cask_to_winget: HashMap<String, String>,
+    winget_to_brew_formula: HashMap<String, String>,
+    winget_to_brew_cask: HashMap<String, String>,
+}
+
+impl MappingTable {
+    pub fn build(config_overrides: &[MappingEntry]) -> Self {
+        let mut table = Self {
+            brew_formula_to_winget: HashMap::new(),
+            brew_cask_to_winget: HashMap::new(),
+            winget_to_brew_formula: HashMap::new(),
+            winget_to_brew_cask: HashMap::new(),
+        };
+
+        // Load built-in defaults
+        for m in default_mappings() {
+            table.insert_mapping(
+                m.brew_formula.map(|s| s.to_string()),
+                m.brew_cask.map(|s| s.to_string()),
+                m.winget.map(|s| s.to_string()),
+            );
+        }
+
+        // Apply config overrides (overwrite existing entries)
+        for entry in config_overrides {
+            table.insert_mapping(entry.brew.clone(), entry.cask.clone(), entry.winget.clone());
+        }
+
+        table
+    }
+
+    fn insert_mapping(
+        &mut self,
+        brew_formula: Option<String>,
+        brew_cask: Option<String>,
+        winget: Option<String>,
+    ) {
+        if let (Some(formula), Some(wg)) = (&brew_formula, &winget) {
+            // Remove stale reverse entry if this formula previously mapped to a different winget ID
+            if let Some(old_wg) = self.brew_formula_to_winget.get(formula) {
+                if *old_wg != *wg {
+                    self.winget_to_brew_formula.remove(&old_wg.to_lowercase());
+                }
+            }
+            self.brew_formula_to_winget
+                .insert(formula.clone(), wg.clone());
+            self.winget_to_brew_formula
+                .insert(wg.to_lowercase(), formula.clone());
+        }
+        if let (Some(cask), Some(wg)) = (&brew_cask, &winget) {
+            if let Some(old_wg) = self.brew_cask_to_winget.get(cask) {
+                if *old_wg != *wg {
+                    self.winget_to_brew_cask.remove(&old_wg.to_lowercase());
+                }
+            }
+            self.brew_cask_to_winget.insert(cask.clone(), wg.clone());
+            self.winget_to_brew_cask
+                .insert(wg.to_lowercase(), cask.clone());
+        }
+    }
+
+    /// Map brew formula names to winget IDs.
+    pub fn formulae_to_winget<'a>(&self, formulae: &'a [String]) -> Vec<(&'a str, &str)> {
+        formulae
+            .iter()
+            .filter_map(|f| {
+                self.brew_formula_to_winget
+                    .get(f.as_str())
+                    .map(|wg| (f.as_str(), wg.as_str()))
+            })
+            .collect()
+    }
+
+    /// Map brew cask names to winget IDs.
+    pub fn casks_to_winget<'a>(&self, casks: &'a [String]) -> Vec<(&'a str, &str)> {
+        casks
+            .iter()
+            .filter_map(|c| {
+                self.brew_cask_to_winget
+                    .get(c.as_str())
+                    .map(|wg| (c.as_str(), wg.as_str()))
+            })
+            .collect()
+    }
+
+    /// Map winget IDs to brew formula names.
+    pub fn winget_to_formulae<'a>(&self, ids: &'a [String]) -> Vec<(&'a str, &str)> {
+        ids.iter()
+            .filter_map(|id| {
+                self.winget_to_brew_formula
+                    .get(&id.to_lowercase())
+                    .map(|f| (id.as_str(), f.as_str()))
+            })
+            .collect()
+    }
+
+    /// Map winget IDs to brew cask names.
+    pub fn winget_to_casks<'a>(&self, ids: &'a [String]) -> Vec<(&'a str, &str)> {
+        ids.iter()
+            .filter_map(|id| {
+                self.winget_to_brew_cask
+                    .get(&id.to_lowercase())
+                    .map(|c| (id.as_str(), c.as_str()))
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builtin_formula_to_winget() {
+        let table = MappingTable::build(&[]);
+        let formulae = vec!["git".to_string(), "unknown-pkg".to_string()];
+        let mapped = table.formulae_to_winget(&formulae);
+        assert_eq!(mapped.len(), 1);
+        assert_eq!(mapped[0], ("git", "Git.Git"));
+    }
+
+    #[test]
+    fn test_builtin_cask_to_winget() {
+        let table = MappingTable::build(&[]);
+        let casks = vec!["visual-studio-code".to_string()];
+        let mapped = table.casks_to_winget(&casks);
+        assert_eq!(mapped.len(), 1);
+        assert_eq!(
+            mapped[0],
+            ("visual-studio-code", "Microsoft.VisualStudioCode")
+        );
+    }
+
+    #[test]
+    fn test_winget_to_formula() {
+        let table = MappingTable::build(&[]);
+        let ids = vec!["Git.Git".to_string(), "Unknown.Pkg".to_string()];
+        let mapped = table.winget_to_formulae(&ids);
+        assert_eq!(mapped.len(), 1);
+        assert_eq!(mapped[0], ("Git.Git", "git"));
+    }
+
+    #[test]
+    fn test_winget_to_cask() {
+        let table = MappingTable::build(&[]);
+        let ids = vec!["Microsoft.VisualStudioCode".to_string()];
+        let mapped = table.winget_to_casks(&ids);
+        assert_eq!(mapped.len(), 1);
+        assert_eq!(
+            mapped[0],
+            ("Microsoft.VisualStudioCode", "visual-studio-code")
+        );
+    }
+
+    #[test]
+    fn test_config_override() {
+        let overrides = vec![MappingEntry {
+            brew: Some("my-tool".to_string()),
+            cask: None,
+            winget: Some("MyOrg.MyTool".to_string()),
+        }];
+        let table = MappingTable::build(&overrides);
+        let formulae = vec!["my-tool".to_string()];
+        let mapped = table.formulae_to_winget(&formulae);
+        assert_eq!(mapped.len(), 1);
+        assert_eq!(mapped[0], ("my-tool", "MyOrg.MyTool"));
+    }
+
+    #[test]
+    fn test_config_override_replaces_builtin() {
+        let overrides = vec![MappingEntry {
+            brew: Some("git".to_string()),
+            cask: None,
+            winget: Some("Custom.Git".to_string()),
+        }];
+        let table = MappingTable::build(&overrides);
+        let formulae = vec!["git".to_string()];
+        let mapped = table.formulae_to_winget(&formulae);
+        assert_eq!(mapped[0], ("git", "Custom.Git"));
+    }
+
+    #[test]
+    fn test_override_removes_stale_reverse_entry() {
+        // Builtin: git → Git.Git. Override: git → Custom.Git.
+        // The old reverse entry Git.Git → git should be removed.
+        let overrides = vec![MappingEntry {
+            brew: Some("git".to_string()),
+            cask: None,
+            winget: Some("Custom.Git".to_string()),
+        }];
+        let table = MappingTable::build(&overrides);
+        let ids = vec!["Git.Git".to_string()];
+        let mapped = table.winget_to_formulae(&ids);
+        assert!(mapped.is_empty());
+    }
+
+    #[test]
+    fn test_winget_lookup_case_insensitive() {
+        let table = MappingTable::build(&[]);
+        let ids = vec!["git.git".to_string()];
+        let mapped = table.winget_to_formulae(&ids);
+        assert_eq!(mapped.len(), 1);
+        assert_eq!(mapped[0], ("git.git", "git"));
+    }
+}

--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -2,9 +2,11 @@ pub mod brew;
 pub mod bun;
 pub mod gem;
 pub mod manager;
+pub mod mapping;
 pub mod npm;
 pub mod pnpm;
 pub mod uv;
+pub mod winget;
 
 pub use brew::{normalize_formula_name, BrewManager, BrewfilePackages};
 pub use bun::BunManager;
@@ -13,3 +15,11 @@ pub use manager::{PackageInfo, PackageManager};
 pub use npm::NpmManager;
 pub use pnpm::PnpmManager;
 pub use uv::UvManager;
+pub use winget::WingetManager;
+
+/// Resolve a program name to its full path.
+/// On Windows, `Command::new("npm")` only finds `.exe` files, but tools like
+/// npm/pnpm install as `.cmd` files. `which` respects PATHEXT and finds them.
+pub(crate) fn resolve_program(name: &str) -> std::path::PathBuf {
+    which::which(name).unwrap_or_else(|_| name.into())
+}

--- a/src/packages/npm.rs
+++ b/src/packages/npm.rs
@@ -23,7 +23,10 @@ impl NpmManager {
     }
 
     async fn run_npm(&self, args: &[&str]) -> Result<String> {
-        let output = Command::new("npm").args(args).output().await?;
+        let output = Command::new(super::resolve_program("npm"))
+            .args(args)
+            .output()
+            .await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -89,7 +92,10 @@ impl PackageManager for NpmManager {
             return Ok(());
         }
 
-        let output = Command::new("npm").args(["update", "-g"]).output().await?;
+        let output = Command::new(super::resolve_program("npm"))
+            .args(["update", "-g"])
+            .output()
+            .await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -100,7 +106,7 @@ impl PackageManager for NpmManager {
     }
 
     async fn uninstall(&self, package: &str) -> Result<()> {
-        let output = Command::new("npm")
+        let output = Command::new(super::resolve_program("npm"))
             .args(["uninstall", "-g", package])
             .output()
             .await?;

--- a/src/packages/pnpm.rs
+++ b/src/packages/pnpm.rs
@@ -12,7 +12,10 @@ impl PnpmManager {
     }
 
     async fn run_pnpm(&self, args: &[&str]) -> Result<String> {
-        let output = Command::new("pnpm").args(args).output().await?;
+        let output = Command::new(super::resolve_program("pnpm"))
+            .args(args)
+            .output()
+            .await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -90,7 +93,10 @@ impl PackageManager for PnpmManager {
             return Ok(());
         }
 
-        let output = Command::new("pnpm").args(["update", "-g"]).output().await?;
+        let output = Command::new(super::resolve_program("pnpm"))
+            .args(["update", "-g"])
+            .output()
+            .await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -101,7 +107,7 @@ impl PackageManager for PnpmManager {
     }
 
     async fn uninstall(&self, package: &str) -> Result<()> {
-        let output = Command::new("pnpm")
+        let output = Command::new(super::resolve_program("pnpm"))
             .args(["remove", "-g", package])
             .output()
             .await?;

--- a/src/packages/uv.rs
+++ b/src/packages/uv.rs
@@ -11,7 +11,10 @@ impl UvManager {
     }
 
     async fn run_uv(&self, args: &[&str]) -> Result<String> {
-        let output = Command::new("uv").args(args).output().await?;
+        let output = Command::new(super::resolve_program("uv"))
+            .args(args)
+            .output()
+            .await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -83,7 +86,7 @@ impl PackageManager for UvManager {
             return Ok(());
         }
 
-        let output = Command::new("uv")
+        let output = Command::new(super::resolve_program("uv"))
             .args(["tool", "upgrade", "--all"])
             .output()
             .await?;
@@ -97,7 +100,7 @@ impl PackageManager for UvManager {
     }
 
     async fn uninstall(&self, package: &str) -> Result<()> {
-        let output = Command::new("uv")
+        let output = Command::new(super::resolve_program("uv"))
             .args(["tool", "uninstall", package])
             .output()
             .await?;

--- a/src/packages/winget.rs
+++ b/src/packages/winget.rs
@@ -49,6 +49,8 @@ impl PackageManager for WingetManager {
             &package.name,
             "-e",
             "--disable-interactivity",
+            "--accept-source-agreements",
+            "--accept-package-agreements",
         ];
         let version_str;
         if let Some(version) = &package.version {
@@ -95,7 +97,7 @@ impl PackageManager for WingetManager {
         for id in package_ids {
             if !installed_ids.contains(&id.to_lowercase()) {
                 let output = Command::new(super::resolve_program("winget"))
-                    .args(["install", "--id", id, "-e", "--disable-interactivity"])
+                    .args(["install", "--id", id, "-e", "--disable-interactivity", "--accept-source-agreements", "--accept-package-agreements"])
                     .output()
                     .await?;
 
@@ -147,7 +149,7 @@ impl PackageManager for WingetManager {
 
     async fn update_all(&self) -> Result<()> {
         let output = Command::new(super::resolve_program("winget"))
-            .args(["upgrade", "--all", "--disable-interactivity"])
+            .args(["upgrade", "--all", "--disable-interactivity", "--accept-source-agreements", "--accept-package-agreements"])
             .output()
             .await?;
 

--- a/src/packages/winget.rs
+++ b/src/packages/winget.rs
@@ -1,0 +1,348 @@
+use super::{PackageInfo, PackageManager};
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio::process::Command;
+
+pub struct WingetManager;
+
+impl WingetManager {
+    pub fn new() -> Self {
+        Self
+    }
+
+    async fn run_winget(&self, args: &[&str]) -> Result<String> {
+        let output = Command::new(super::resolve_program("winget"))
+            .args(args)
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!("winget command failed: {}", stderr));
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+}
+
+impl Default for WingetManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl PackageManager for WingetManager {
+    async fn list_installed(&self) -> Result<Vec<PackageInfo>> {
+        let output = self
+            .run_winget(&["list", "--source", "winget", "--disable-interactivity"])
+            .await?;
+
+        let packages = parse_winget_list(&output);
+        Ok(packages)
+    }
+
+    async fn install(&self, package: &PackageInfo) -> Result<()> {
+        let mut args = vec![
+            "install",
+            "--id",
+            &package.name,
+            "-e",
+            "--disable-interactivity",
+        ];
+        let version_str;
+        if let Some(version) = &package.version {
+            version_str = version.clone();
+            args.extend(["--version", &version_str]);
+        }
+        self.run_winget(&args).await?;
+        Ok(())
+    }
+
+    async fn is_available(&self) -> bool {
+        which::which("winget").is_ok()
+    }
+
+    fn name(&self) -> &str {
+        "winget"
+    }
+
+    async fn export_manifest(&self) -> Result<String> {
+        let packages = self.list_installed().await?;
+        let manifest = packages
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        Ok(manifest)
+    }
+
+    async fn import_manifest(&self, manifest_content: &str) -> Result<()> {
+        let package_ids: Vec<&str> = manifest_content
+            .lines()
+            .map(|line| line.trim())
+            .filter(|line| !line.is_empty())
+            .collect();
+
+        if package_ids.is_empty() {
+            return Ok(());
+        }
+
+        let installed = self.list_installed().await?;
+        let installed_ids: std::collections::HashSet<_> =
+            installed.iter().map(|p| p.name.to_lowercase()).collect();
+
+        for id in package_ids {
+            if !installed_ids.contains(&id.to_lowercase()) {
+                let output = Command::new(super::resolve_program("winget"))
+                    .args(["install", "--id", id, "-e", "--disable-interactivity"])
+                    .output()
+                    .await?;
+
+                if !output.status.success() {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    eprintln!("Warning: Failed to install {}: {}", id, stderr);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn remove_unlisted(&self, manifest_content: &str) -> Result<()> {
+        let desired: std::collections::HashSet<String> = manifest_content
+            .lines()
+            .map(|l| l.trim().to_lowercase())
+            .filter(|l| !l.is_empty())
+            .collect();
+
+        if desired.is_empty() {
+            return Ok(());
+        }
+
+        let installed = self.list_installed().await?;
+
+        for pkg in installed {
+            if !desired.contains(&pkg.name.to_lowercase()) {
+                let output = Command::new(super::resolve_program("winget"))
+                    .args([
+                        "uninstall",
+                        "--id",
+                        &pkg.name,
+                        "-e",
+                        "--disable-interactivity",
+                    ])
+                    .output()
+                    .await?;
+
+                if !output.status.success() {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    eprintln!("Warning: Failed to uninstall {}: {}", pkg.name, stderr);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn update_all(&self) -> Result<()> {
+        let output = Command::new(super::resolve_program("winget"))
+            .args(["upgrade", "--all", "--disable-interactivity"])
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!("winget upgrade failed: {}", stderr));
+        }
+
+        Ok(())
+    }
+
+    async fn uninstall(&self, package: &str) -> Result<()> {
+        let output = Command::new(super::resolve_program("winget"))
+            .args([
+                "uninstall",
+                "--id",
+                package,
+                "-e",
+                "--disable-interactivity",
+            ])
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!("winget uninstall failed: {}", stderr));
+        }
+
+        Ok(())
+    }
+}
+
+/// Approximate display width of a char. CJK ideographs and fullwidth forms are 2 columns.
+fn display_width(c: char) -> usize {
+    let cp = c as u32;
+    if (0x1100..=0x115F).contains(&cp)    // Hangul Jamo
+        || (0x2E80..=0x303E).contains(&cp)  // CJK radicals, symbols
+        || (0x3040..=0x33BF).contains(&cp)  // Hiragana, Katakana, CJK compat
+        || (0x3400..=0x4DBF).contains(&cp)  // CJK Extension A
+        || (0x4E00..=0x9FFF).contains(&cp)  // CJK Unified Ideographs
+        || (0xA960..=0xA97C).contains(&cp)  // Hangul Jamo Extended-A
+        || (0xAC00..=0xD7A3).contains(&cp)  // Hangul Syllables
+        || (0xF900..=0xFAFF).contains(&cp)  // CJK Compatibility Ideographs
+        || (0xFE10..=0xFE6F).contains(&cp)  // CJK compatibility forms, small forms
+        || (0xFF01..=0xFF60).contains(&cp)  // Fullwidth forms
+        || (0xFFE0..=0xFFE6).contains(&cp)  // Fullwidth signs
+        || (0x20000..=0x2FA1F).contains(&cp)
+    // CJK extensions B-F, compat supplement
+    {
+        2
+    } else {
+        1
+    }
+}
+
+/// Slice a string by display column position, returning the substring between [start, end).
+fn slice_by_display_col(s: &str, start: usize, end: usize) -> &str {
+    let mut col = 0;
+    let mut byte_start = s.len();
+    let mut byte_end = s.len();
+    for (i, c) in s.char_indices() {
+        if col >= end {
+            byte_end = i;
+            break;
+        }
+        if col >= start && byte_start == s.len() {
+            byte_start = i;
+        }
+        col += display_width(c);
+    }
+    if byte_start > s.len() {
+        return "";
+    }
+    &s[byte_start..byte_end]
+}
+
+/// Parse `winget list` fixed-width column output by reading column positions from the header.
+/// Header is ASCII so byte offsets == display columns. Data lines are sliced by display width
+/// to handle non-ASCII package names (e.g., CJK double-width characters).
+fn parse_winget_list(output: &str) -> Vec<PackageInfo> {
+    let lines: Vec<&str> = output.lines().collect();
+
+    // Find the header line containing "Id" and "Version"
+    let Some(header_idx) = lines
+        .iter()
+        .position(|l| l.contains("Id") && l.contains("Version"))
+    else {
+        return Vec::new();
+    };
+    let header = lines[header_idx];
+
+    // Header is ASCII, so byte offset == display column
+    let Some(id_col) = header.find("Id") else {
+        return Vec::new();
+    };
+    let version_col = header.find("Version").unwrap_or(header.len());
+
+    // Find the separator line (dashes) after header
+    let data_start = lines
+        .iter()
+        .enumerate()
+        .skip(header_idx + 1)
+        .find(|(_, l)| l.starts_with('-'))
+        .map(|(i, _)| i + 1)
+        .unwrap_or(header_idx + 1);
+
+    let mut packages = Vec::new();
+    for line in lines.iter().skip(data_start) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let id = slice_by_display_col(line, id_col, version_col).trim();
+        let version = {
+            let rest = slice_by_display_col(line, version_col, usize::MAX).trim();
+            let v = rest.split_whitespace().next().unwrap_or("");
+            if v.is_empty() {
+                None
+            } else {
+                Some(v.to_string())
+            }
+        };
+        if !id.is_empty() {
+            packages.push(PackageInfo {
+                name: id.to_string(),
+                version,
+            });
+        }
+    }
+
+    packages.sort_by(|a, b| a.name.cmp(&b.name));
+    packages
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_winget_list_basic() {
+        let output = "\
+Name                            Id                          Version   Available Source
+-----------------------------------------------------------------------------------------------
+Git                             Git.Git                     2.43.0    2.44.0    winget
+Visual Studio Code              Microsoft.VisualStudioCode  1.87.0              winget
+Microsoft Edge                  Microsoft.Edge              122.0     123.0     winget";
+
+        let packages = parse_winget_list(output);
+        assert_eq!(packages.len(), 3);
+        assert_eq!(packages[0].name, "Git.Git");
+        assert_eq!(packages[0].version, Some("2.43.0".to_string()));
+        assert_eq!(packages[1].name, "Microsoft.Edge");
+        assert_eq!(packages[2].name, "Microsoft.VisualStudioCode");
+        assert_eq!(packages[2].version, Some("1.87.0".to_string()));
+    }
+
+    #[test]
+    fn test_parse_winget_list_with_preamble() {
+        let output = "\
+Some winget preamble text
+Another line of output
+Name                Id                Version  Source
+-----------------------------------------------------
+Git                 Git.Git           2.43.0   winget";
+
+        let packages = parse_winget_list(output);
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name, "Git.Git");
+    }
+
+    #[test]
+    fn test_parse_winget_list_empty() {
+        let packages = parse_winget_list("");
+        assert!(packages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_winget_list_no_header() {
+        let packages = parse_winget_list("some random output\nwith no header");
+        assert!(packages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_winget_list_non_ascii_names() {
+        // CJK chars are double-width in terminal display; winget aligns by display columns.
+        // "日本語App" = 3 CJK (6 cols) + 3 ASCII (3 cols) = 9 display cols
+        // Header "Id" starts at display column 20, so pad to 20.
+        let output = "\
+Name                Id                  Version
+-------------------------------------------------
+日本語App           Editor.Japanese     2.1.0
+Блокнот             Notepad.App         1.0.0";
+
+        let packages = parse_winget_list(output);
+        assert_eq!(packages.len(), 2);
+        assert_eq!(packages[0].name, "Editor.Japanese");
+        assert_eq!(packages[1].name, "Notepad.App");
+    }
+}

--- a/src/security/keychain.rs
+++ b/src/security/keychain.rs
@@ -70,7 +70,11 @@ fn cache_key(key: &[u8]) -> Result<()> {
         file.write_all(key)?;
     }
     #[cfg(not(unix))]
-    fs::write(&path, key)?;
+    {
+        fs::write(&path, key)?;
+        #[cfg(windows)]
+        super::restrict_file_permissions(&path)?;
+    }
 
     Ok(())
 }

--- a/src/security/recipients.rs
+++ b/src/security/recipients.rs
@@ -68,7 +68,11 @@ pub fn store_identity(identity: &age::x25519::Identity, passphrase: &str) -> Res
         file.write_all(&encrypted)?;
     }
     #[cfg(not(unix))]
-    fs::write(&path, &encrypted)?;
+    {
+        fs::write(&path, &encrypted)?;
+        #[cfg(windows)]
+        super::restrict_file_permissions(&path)?;
+    }
 
     // Also store public key for easy sharing
     let pubkey = identity.to_public().to_string();
@@ -145,7 +149,11 @@ fn cache_identity(identity: &age::x25519::Identity) -> Result<()> {
         file.write_all(identity_str.expose_secret().as_bytes())?;
     }
     #[cfg(not(unix))]
-    fs::write(&path, identity_str.expose_secret())?;
+    {
+        fs::write(&path, identity_str.expose_secret())?;
+        #[cfg(windows)]
+        super::restrict_file_permissions(&path)?;
+    }
 
     Ok(())
 }

--- a/src/sync/conflict.rs
+++ b/src/sync/conflict.rs
@@ -323,6 +323,7 @@ impl ConflictState {
 }
 
 /// Escape a string for safe use in AppleScript
+#[cfg(target_os = "macos")]
 fn escape_applescript(s: &str) -> String {
     // Remove any control characters and limit length for safety
     let sanitized: String = s.chars().filter(|c| !c.is_control()).take(100).collect();
@@ -330,50 +331,60 @@ fn escape_applescript(s: &str) -> String {
     sanitized.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
-/// Send macOS notification about conflict
+/// Send desktop notification about conflict
 pub fn notify_conflict(file_path: &str) -> Result<()> {
-    use std::process::Command;
-
-    let safe_path = escape_applescript(file_path);
-    let script = format!(
-        r#"display notification "Conflict detected in {}" with title "Tether" subtitle "Run 'tether resolve' to fix""#,
-        safe_path
-    );
-
-    Command::new("osascript").args(["-e", &script]).output()?;
-
-    Ok(())
+    send_notification(
+        &format!("Conflict detected in {file_path}"),
+        "Run 'tether resolve' to fix",
+    )
 }
 
-/// Send macOS notification about multiple conflicts
+/// Send desktop notification about multiple conflicts
 pub fn notify_conflicts(count: usize) -> Result<()> {
+    send_notification(
+        &format!("{count} file conflicts detected"),
+        "Run 'tether resolve' to fix",
+    )
+}
+
+/// Send desktop notification about deferred casks
+pub fn notify_deferred_casks(casks: &[String]) -> Result<()> {
+    let count = casks.len();
+    let s = if count == 1 { "" } else { "s" };
+    let verb = if count == 1 { "s" } else { "" };
+    send_notification(
+        &format!("{count} cask{s} need{verb} password"),
+        "Run 'tether sync' to install",
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn send_notification(message: &str, subtitle: &str) -> Result<()> {
     use std::process::Command;
-
-    // count is a usize, no escaping needed
-    let script = format!(
-        r#"display notification "{} file conflicts detected" with title "Tether" subtitle "Run 'tether resolve' to fix""#,
-        count
-    );
-
+    let safe_msg = escape_applescript(message);
+    let safe_sub = escape_applescript(subtitle);
+    let script =
+        format!(r#"display notification "{safe_msg}" with title "Tether" subtitle "{safe_sub}""#);
     Command::new("osascript").args(["-e", &script]).output()?;
-
     Ok(())
 }
 
-/// Send macOS notification about deferred casks
-pub fn notify_deferred_casks(casks: &[String]) -> Result<()> {
+#[cfg(target_os = "windows")]
+fn send_notification(message: &str, subtitle: &str) -> Result<()> {
     use std::process::Command;
+    // Pass values via env vars to avoid PowerShell injection through string interpolation
+    let script = r#"[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] > $null; $xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02); $text = $xml.GetElementsByTagName('text'); $text.Item(0).AppendChild($xml.CreateTextNode("Tether: $env:TETHER_SUB")) > $null; $text.Item(1).AppendChild($xml.CreateTextNode($env:TETHER_MSG)) > $null; [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Tether').Show([Windows.UI.Notifications.ToastNotification]::new($xml))"#;
+    Command::new("powershell")
+        .env("TETHER_SUB", subtitle)
+        .env("TETHER_MSG", message)
+        .args(["-Command", script])
+        .output()?;
+    Ok(())
+}
 
-    let count = casks.len();
-    let script = format!(
-        r#"display notification "{} cask{} need{} password" with title "Tether" subtitle "Run 'tether sync' to install""#,
-        count,
-        if count == 1 { "" } else { "s" },
-        if count == 1 { "s" } else { "" }
-    );
-
-    Command::new("osascript").args(["-e", &script]).output()?;
-
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn send_notification(message: &str, _subtitle: &str) -> Result<()> {
+    log::info!("Notification: {message}");
     Ok(())
 }
 
@@ -505,21 +516,25 @@ mod tests {
     }
 
     // escape_applescript tests
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_escape_applescript_plain() {
         assert_eq!(escape_applescript("hello"), "hello");
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_escape_applescript_quotes() {
         assert_eq!(escape_applescript("hello\"world"), "hello\\\"world");
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_escape_applescript_backslashes() {
         assert_eq!(escape_applescript("path\\to\\file"), "path\\\\to\\\\file");
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_escape_applescript_truncates_long() {
         let long = "a".repeat(200);
@@ -527,6 +542,7 @@ mod tests {
         assert!(escaped.len() <= 100);
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_escape_applescript_removes_control_chars() {
         let with_control = "hello\nworld\ttab";

--- a/src/sync/conflict.rs
+++ b/src/sync/conflict.rs
@@ -369,7 +369,7 @@ fn send_notification(message: &str, subtitle: &str) -> Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 fn send_notification(message: &str, subtitle: &str) -> Result<()> {
     use std::process::Command;
     // Pass values via env vars to avoid PowerShell injection through string interpolation

--- a/src/sync/packages.rs
+++ b/src/sync/packages.rs
@@ -2,7 +2,7 @@ use crate::cli::Output;
 use crate::config::Config;
 use crate::packages::{
     normalize_formula_name, BrewManager, BrewfilePackages, BunManager, GemManager, NpmManager,
-    PackageManager, PnpmManager, UvManager,
+    PackageManager, PnpmManager, UvManager, WingetManager,
 };
 use crate::sync::state::PackageState;
 use crate::sync::{MachineState, SyncState};
@@ -46,6 +46,11 @@ const SIMPLE_MANAGERS: &[PackageManagerDef] = &[
         state_key: "uv",
         display_name: "uv",
         manifest_file: "uv.txt",
+    },
+    PackageManagerDef {
+        state_key: "winget",
+        display_name: "winget",
+        manifest_file: "winget.txt",
     },
 ];
 
@@ -91,6 +96,7 @@ pub async fn import_packages(
             "bun" => config.packages.bun.enabled,
             "gem" => config.packages.gem.enabled,
             "uv" => config.packages.uv.enabled,
+            "winget" => config.packages.winget.enabled,
             _ => false,
         };
 
@@ -102,7 +108,173 @@ pub async fn import_packages(
         }
     }
 
+    // Cross-platform mapping: brew ↔ winget
+    if config.packages.cross_platform_sync
+        && import_cross_platform(config, &manifests_dir, machine_state).await
+    {
+        let key = if cfg!(target_os = "windows") {
+            "winget"
+        } else {
+            "brew"
+        };
+        update_last_upgrade(state, key);
+    }
+
     Ok(deferred_casks)
+}
+
+/// Import packages cross-platform using brew ↔ winget mappings.
+/// On Windows: reads Brewfile, maps to winget IDs, installs missing.
+/// On macOS: reads winget.txt, maps to brew formulas/casks, installs missing.
+async fn import_cross_platform(
+    config: &Config,
+    manifests_dir: &Path,
+    machine_state: &MachineState,
+) -> bool {
+    use crate::packages::mapping::MappingTable;
+
+    let table = MappingTable::build(&config.packages.mapping);
+    let mut installed = false;
+
+    // On Windows: read Brewfile → install winget equivalents
+    if cfg!(target_os = "windows") && config.packages.winget.enabled {
+        let winget = WingetManager::new();
+        if winget.is_available().await {
+            if let Some(manifest) = manifests_dir
+                .join("Brewfile")
+                .exists()
+                .then(|| std::fs::read_to_string(manifests_dir.join("Brewfile")).ok())
+                .flatten()
+            {
+                let brew_packages = BrewfilePackages::parse(&manifest);
+
+                let local_winget: HashSet<String> = machine_state
+                    .packages
+                    .get("winget")
+                    .map(|v| v.iter().map(|s| s.to_lowercase()).collect())
+                    .unwrap_or_default();
+                let removed_winget: HashSet<String> = machine_state
+                    .removed_packages
+                    .get("winget")
+                    .map(|v| v.iter().map(|s| s.to_lowercase()).collect())
+                    .unwrap_or_default();
+
+                let mut to_install: Vec<String> = Vec::new();
+
+                for (_brew_name, winget_id) in table.formulae_to_winget(&brew_packages.formulae) {
+                    let id_lower = winget_id.to_lowercase();
+                    if !local_winget.contains(&id_lower) && !removed_winget.contains(&id_lower) {
+                        to_install.push(winget_id.to_string());
+                    }
+                }
+
+                for (_cask_name, winget_id) in table.casks_to_winget(&brew_packages.casks) {
+                    let id_lower = winget_id.to_lowercase();
+                    if !local_winget.contains(&id_lower) && !removed_winget.contains(&id_lower) {
+                        to_install.push(winget_id.to_string());
+                    }
+                }
+
+                if !to_install.is_empty() {
+                    Output::info(&format!(
+                        "Cross-platform: installing {} winget package{} from Brewfile...",
+                        to_install.len(),
+                        if to_install.len() == 1 { "" } else { "s" }
+                    ));
+                    let manifest_str = to_install.join("\n") + "\n";
+                    match winget.import_manifest(&manifest_str).await {
+                        Ok(_) => installed = true,
+                        Err(e) => {
+                            Output::warning(&format!("Cross-platform winget import failed: {}", e))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // On macOS: read winget.txt → install brew equivalents
+    if cfg!(target_os = "macos") && config.packages.brew.enabled {
+        let brew = BrewManager::new();
+        if brew.is_available().await {
+            if let Some(manifest) = manifests_dir
+                .join("winget.txt")
+                .exists()
+                .then(|| std::fs::read_to_string(manifests_dir.join("winget.txt")).ok())
+                .flatten()
+            {
+                let winget_ids: Vec<String> = manifest
+                    .lines()
+                    .filter(|l| !l.trim().is_empty())
+                    .map(|s| s.trim().to_string())
+                    .collect();
+
+                let local_formulae: HashSet<_> = machine_state
+                    .packages
+                    .get("brew_formulae")
+                    .map(|v| v.iter().map(|s| s.as_str()).collect())
+                    .unwrap_or_default();
+                let local_casks: HashSet<_> = machine_state
+                    .packages
+                    .get("brew_casks")
+                    .map(|v| v.iter().map(|s| s.as_str()).collect())
+                    .unwrap_or_default();
+                let removed_formulae: HashSet<_> = machine_state
+                    .removed_packages
+                    .get("brew_formulae")
+                    .map(|v| v.iter().map(|s| s.as_str()).collect())
+                    .unwrap_or_default();
+                let removed_casks: HashSet<_> = machine_state
+                    .removed_packages
+                    .get("brew_casks")
+                    .map(|v| v.iter().map(|s| s.as_str()).collect())
+                    .unwrap_or_default();
+
+                let mut formulae_to_install: Vec<String> = Vec::new();
+                let mut casks_to_install: Vec<String> = Vec::new();
+
+                for (_winget_id, formula) in table.winget_to_formulae(&winget_ids) {
+                    if !local_formulae.contains(formula) && !removed_formulae.contains(formula) {
+                        formulae_to_install.push(formula.to_string());
+                    }
+                }
+
+                for (_winget_id, cask) in table.winget_to_casks(&winget_ids) {
+                    if !local_casks.contains(cask) && !removed_casks.contains(cask) {
+                        casks_to_install.push(cask.to_string());
+                    }
+                }
+
+                let total = formulae_to_install.len() + casks_to_install.len();
+                if total > 0 {
+                    Output::info(&format!(
+                        "Cross-platform: installing {} brew package{} from winget manifest...",
+                        total,
+                        if total == 1 { "" } else { "s" }
+                    ));
+
+                    if !formulae_to_install.is_empty() {
+                        let brew_pkgs = BrewfilePackages {
+                            taps: Vec::new(),
+                            formulae: formulae_to_install,
+                            casks: Vec::new(),
+                        };
+                        if brew.import_manifest(&brew_pkgs.generate()).await.is_ok() {
+                            installed = true;
+                        }
+                    }
+
+                    for cask in &casks_to_install {
+                        if brew.install_cask(cask, true).await.is_ok() {
+                            installed = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    installed
 }
 
 /// Update last_upgrade timestamp for a package manager
@@ -306,6 +478,7 @@ async fn import_simple_manager(
         "bun" => Box::new(BunManager::new()),
         "gem" => Box::new(GemManager::new()),
         "uv" => Box::new(UvManager::new()),
+        "winget" => Box::new(WingetManager::new()),
         _ => return false,
     };
 
@@ -318,16 +491,38 @@ async fn import_simple_manager(
         Err(_) => return false,
     };
 
-    let local_packages: HashSet<_> = machine_state
+    let case_insensitive = def.state_key == "winget";
+
+    let local_packages: HashSet<String> = machine_state
         .packages
         .get(def.state_key)
-        .map(|v| v.iter().cloned().collect())
+        .map(|v| {
+            v.iter()
+                .map(|s| {
+                    if case_insensitive {
+                        s.to_lowercase()
+                    } else {
+                        s.clone()
+                    }
+                })
+                .collect()
+        })
         .unwrap_or_default();
 
-    let removed_packages: HashSet<_> = machine_state
+    let removed_packages: HashSet<String> = machine_state
         .removed_packages
         .get(def.state_key)
-        .map(|v| v.iter().cloned().collect())
+        .map(|v| {
+            v.iter()
+                .map(|s| {
+                    if case_insensitive {
+                        s.to_lowercase()
+                    } else {
+                        s.clone()
+                    }
+                })
+                .collect()
+        })
         .unwrap_or_default();
 
     // Filter to only missing packages
@@ -335,7 +530,12 @@ async fn import_simple_manager(
         .lines()
         .filter(|line| {
             let pkg = line.trim();
-            !pkg.is_empty() && !removed_packages.contains(pkg) && !local_packages.contains(pkg)
+            let key = if case_insensitive {
+                pkg.to_lowercase()
+            } else {
+                pkg.to_string()
+            };
+            !pkg.is_empty() && !removed_packages.contains(&key) && !local_packages.contains(&key)
         })
         .map(|s| s.to_string())
         .collect();
@@ -405,6 +605,7 @@ pub async fn sync_packages(
             "bun" => config.packages.bun.enabled,
             "gem" => config.packages.gem.enabled,
             "uv" => config.packages.uv.enabled,
+            "winget" => config.packages.winget.enabled,
             _ => false,
         };
 

--- a/src/sync/team.rs
+++ b/src/sync/team.rs
@@ -357,39 +357,13 @@ impl SymlinkableDir {
                     std::fs::remove_file(&target_item)?; // Remove old symlink if exists
                 }
 
-                #[cfg(unix)]
-                std::os::unix::fs::symlink(&team_item, &target_item).with_context(|| {
+                super::create_symlink(&team_item, &target_item).with_context(|| {
                     format!(
                         "Failed to create symlink: {} -> {}",
                         target_item.display(),
                         team_item.display()
                     )
                 })?;
-
-                #[cfg(windows)]
-                {
-                    if team_item.is_dir() {
-                        std::os::windows::fs::symlink_dir(&team_item, &target_item).with_context(
-                            || {
-                                format!(
-                                    "Failed to create directory symlink: {} -> {}",
-                                    target_item.display(),
-                                    team_item.display()
-                                )
-                            },
-                        )?;
-                    } else {
-                        std::os::windows::fs::symlink_file(&team_item, &target_item).with_context(
-                            || {
-                                format!(
-                                    "Failed to create file symlink: {} -> {}",
-                                    target_item.display(),
-                                    team_item.display()
-                                )
-                            },
-                        )?;
-                    }
-                }
 
                 manifest.add_symlink(team_name, target_item.clone(), team_item);
                 results.push(SymlinkResult::Created(target_item));
@@ -526,18 +500,8 @@ pub fn resolve_conflict(target: &Path, team_source: &Path) -> Result<ConflictRes
             std::fs::rename(target, &personal_backup).context("Failed to rename personal file")?;
 
             // Create symlink to team config
-            #[cfg(unix)]
-            std::os::unix::fs::symlink(team_source, target)
+            super::create_symlink(team_source, target)
                 .context("Failed to create symlink after renaming personal")?;
-
-            #[cfg(windows)]
-            {
-                if team_source.is_dir() {
-                    std::os::windows::fs::symlink_dir(team_source, target)?;
-                } else {
-                    std::os::windows::fs::symlink_file(team_source, target)?;
-                }
-            }
 
             Output::success(&format!(
                 "Personal file renamed to: {}",
@@ -549,18 +513,8 @@ pub fn resolve_conflict(target: &Path, team_source: &Path) -> Result<ConflictRes
             // Create team symlink with .team suffix
             let team_link = target.with_extension("team");
 
-            #[cfg(unix)]
-            std::os::unix::fs::symlink(team_source, &team_link)
+            super::create_symlink(team_source, &team_link)
                 .context("Failed to create team symlink")?;
-
-            #[cfg(windows)]
-            {
-                if team_source.is_dir() {
-                    std::os::windows::fs::symlink_dir(team_source, &team_link)?;
-                } else {
-                    std::os::windows::fs::symlink_file(team_source, &team_link)?;
-                }
-            }
 
             Output::success(&format!("Team config linked as: {}", team_link.display()));
             Ok(ConflictResolution::TeamRenamed)


### PR DESCRIPTION
## Summary
- Add Windows platform support with winget package manager
- Cross-platform dotfile sync with path normalization and symlink-to-copy fallback
- Windows daemon scheduling via Task Scheduler (XML task definition)
- File permissions via `icacls` on Windows (replaces `chmod 600`)
- CI matrix expanded to include `windows-latest`; release workflow builds `.zip` with SHA256

## Changes
- `src/packages/winget.rs`: full `PackageManager` impl with CJK-aware output parsing
- `src/packages/mapping.rs`: cross-platform package equivalence mappings
- `src/daemon/pid.rs`: platform-specific process detection (`kill(0)` vs `tasklist`)
- `src/daemon/server.rs`: `#[cfg]`-gated signal handling (Unix signals vs Ctrl+C only)
- `src/cli/commands/daemon.rs`: Task Scheduler install/uninstall/start/stop for Windows
- `src/sync/mod.rs`: path normalization, symlink fallback with privilege error handling
- `src/sync/conflict.rs`: PowerShell toast notifications on Windows
- `src/security/`: `icacls` file permissions, platform-gated keychain access
- `src/config.rs`: Windows-aware defaults (winget enabled, `code` as merge tool)
- `.github/workflows/`: Windows CI test + release build

## Test plan
- [ ] `cargo test` passes on all platforms (CI matrix)
- [ ] `cargo clippy` clean on Windows (no unused import warnings)
- [ ] `tether init` + `tether sync` works on Windows
- [ ] `tether daemon install/start/stop/uninstall` manages Task Scheduler entry
- [ ] Symlink fallback triggers when run without admin privileges