### PR TITLE
fix(sync): remote wins on first sync for create_if_missing files

### DIFF
--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -566,80 +566,96 @@ fn decrypt_from_repo(
 
                         let last_synced_hash = state.files.get(&file).map(|f| f.hash.as_str());
 
-                        // Check for conflict
-                        if let Some(conflict) =
-                            detect_conflict(&file, &local_file, &plaintext, last_synced_hash)
-                        {
-                            if interactive {
-                                // Interactive mode: prompt user
-                                conflict.show_diff()?;
-                                let resolution = conflict.prompt_resolution()?;
+                        // First-time sync: no sync history for this file on this machine.
+                        // Remote content should win over any locally-created default (e.g. an
+                        // app writing an empty {} on startup before tether runs).
+                        let first_sync = last_synced_hash.is_none() && create_if_missing;
 
-                                match resolution {
-                                    ConflictResolution::KeepLocal => {}
-                                    ConflictResolution::UseRemote => {
-                                        // Backup before overwriting
-                                        if local_file.exists() {
-                                            if backup_dir.is_none() {
-                                                backup_dir = Some(create_backup_dir()?);
+                        if !first_sync {
+                            // Check for conflict
+                            if let Some(conflict) =
+                                detect_conflict(&file, &local_file, &plaintext, last_synced_hash)
+                            {
+                                if interactive {
+                                    conflict.show_diff()?;
+                                    let resolution = conflict.prompt_resolution()?;
+
+                                    match resolution {
+                                        ConflictResolution::KeepLocal => {}
+                                        ConflictResolution::UseRemote => {
+                                            if local_file.exists() {
+                                                if backup_dir.is_none() {
+                                                    backup_dir = Some(create_backup_dir()?);
+                                                }
+                                                backup_file(
+                                                    backup_dir.as_ref().unwrap(),
+                                                    "dotfiles",
+                                                    &file,
+                                                    &local_file,
+                                                )?;
                                             }
-                                            backup_file(
-                                                backup_dir.as_ref().unwrap(),
-                                                "dotfiles",
-                                                &file,
-                                                &local_file,
-                                            )?;
+                                            std::fs::write(&local_file, &plaintext)?;
+                                            conflict_state.remove_conflict(&file);
                                         }
-                                        std::fs::write(&local_file, &plaintext)?;
-                                        conflict_state.remove_conflict(&file);
+                                        ConflictResolution::Merged => {
+                                            conflict.launch_merge_tool(&config.merge, home)?;
+                                            conflict_state.remove_conflict(&file);
+                                        }
+                                        ConflictResolution::Skip => {
+                                            new_conflicts.push((
+                                                file.to_string(),
+                                                conflict.local_hash.clone(),
+                                                conflict.remote_hash.clone(),
+                                            ));
+                                        }
                                     }
-                                    ConflictResolution::Merged => {
-                                        conflict.launch_merge_tool(&config.merge, home)?;
-                                        conflict_state.remove_conflict(&file);
-                                    }
-                                    ConflictResolution::Skip => {
-                                        new_conflicts.push((
-                                            file.to_string(),
-                                            conflict.local_hash.clone(),
-                                            conflict.remote_hash.clone(),
-                                        ));
-                                    }
+                                    continue;
+                                } else {
+                                    Output::warning(&format!(
+                                        "  {} (conflict - skipped)",
+                                        file
+                                    ));
+                                    new_conflicts.push((
+                                        file.to_string(),
+                                        conflict.local_hash.clone(),
+                                        conflict.remote_hash.clone(),
+                                    ));
+                                    continue;
                                 }
-                            } else {
-                                // Non-interactive (daemon): save conflict for later
-                                Output::warning(&format!("  {} (conflict - skipped)", file));
-                                new_conflicts.push((
-                                    file.to_string(),
-                                    conflict.local_hash.clone(),
-                                    conflict.remote_hash.clone(),
-                                ));
                             }
-                        } else {
-                            // No true conflict - but preserve local-only changes
-                            let remote_hash = format!("{:x}", Sha256::digest(&plaintext));
-                            let local_hash = std::fs::read(&local_file)
-                                .ok()
-                                .map(|c| format!("{:x}", Sha256::digest(&c)));
-
-                            // Only write if local unchanged from last sync AND remote differs
-                            let local_unchanged = local_hash.as_deref() == last_synced_hash;
-                            if local_unchanged && local_hash.as_ref() != Some(&remote_hash) {
-                                // Backup before overwriting
-                                if local_file.exists() {
-                                    if backup_dir.is_none() {
-                                        backup_dir = Some(create_backup_dir()?);
-                                    }
-                                    backup_file(
-                                        backup_dir.as_ref().unwrap(),
-                                        "dotfiles",
-                                        &file,
-                                        &local_file,
-                                    )?;
-                                }
-                                std::fs::write(&local_file, plaintext)?;
-                            }
-                            conflict_state.remove_conflict(&file);
                         }
+
+                        // Apply remote content if local is unchanged or this is a first sync
+                        let remote_hash = format!("{:x}", Sha256::digest(&plaintext));
+                        let local_hash = std::fs::read(&local_file)
+                            .ok()
+                            .map(|c| format!("{:x}", Sha256::digest(&c)));
+
+                        let should_write = if first_sync {
+                            local_hash.as_ref() != Some(&remote_hash)
+                        } else {
+                            let local_unchanged = local_hash.as_deref() == last_synced_hash;
+                            local_unchanged && local_hash.as_ref() != Some(&remote_hash)
+                        };
+
+                        if should_write {
+                            if local_file.exists() {
+                                if backup_dir.is_none() {
+                                    backup_dir = Some(create_backup_dir()?);
+                                }
+                                backup_file(
+                                    backup_dir.as_ref().unwrap(),
+                                    "dotfiles",
+                                    &file,
+                                    &local_file,
+                                )?;
+                            }
+                            if let Some(parent) = local_file.parent() {
+                                std::fs::create_dir_all(parent)?;
+                            }
+                            std::fs::write(&local_file, plaintext)?;
+                        }
+                        conflict_state.remove_conflict(&file);
                     }
                     Err(e) => {
                         Output::warning(&format!("  {} (failed to decrypt: {})", file, e));


### PR DESCRIPTION
## Why

When a dotfile with `create_if_missing = true` is added to the config and synced to a new machine, the remote content may not be applied — leaving the file empty or with a default value instead of the synced content.

This happens when an application creates the file before tether runs (e.g. Claude Code writes `{}` to `~/.claude/settings.json` on startup). Tether's conflict detection treats that locally-created default as a "local edit" and refuses to overwrite it with the remote version.

## As-Is

1. Machine A adds `.claude/settings.json` (with real content) to tether config and syncs
2. Machine B runs `tether sync` — config is pulled, file doesn't exist locally
3. Before `decrypt_from_repo` writes the remote content, the app creates a default file (e.g. `{}`)
4. `detect_conflict()` sees: local exists (`{}`), no `last_synced_hash`, local ≠ remote → **true conflict**
5. In daemon mode: conflict is skipped. In interactive mode: user is prompted for a file they never edited
6. Even without a conflict, the "no conflict" path checks `local_unchanged = (local_hash == last_synced_hash)` → `Some(hash) == None` → **false** → remote not written

Both code paths fail to apply remote content when there's no sync history for the file.

## To-Be

When `create_if_missing = true` AND there's no sync history for the file on this machine (`last_synced_hash` is None), treat it as a **first-time sync** where remote wins:

1. Skip conflict detection entirely — there's no local state worth preserving
2. Write remote content unless local already matches remote (idempotent)
3. Back up any existing local file before overwriting (safety net)
4. Create parent directories if needed

After the first sync completes, subsequent syncs use the normal three-way conflict detection since `last_synced_hash` will be populated.

## Test plan
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test` passes
- [ ] Add `.claude/settings.json` with `create_if_missing = true` on Machine A, sync
- [ ] On Machine B (where Claude Code already created `{}`), run `tether sync` → file should have Machine A's content
- [ ] On Machine B, edit the file, sync → local edit preserved (normal conflict detection)
- [ ] On Machine C (file doesn't exist at all), run `tether sync` → file created with remote content