### PR TITLE
fix: detect local dotfile changes and merge profile+global dotfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.10] - 2026-04-08
+
+### Fixed
+
+- Dotfiles with no sync history no longer treated as conflicts (prevented daemon from syncing new files)
+- `create_if_missing` dotfiles now receive remote content on first sync even when an app created a default locally
+- `effective_dotfiles()` merges profile + global dotfiles instead of replacing (global entries no longer silently dropped)
+- `effective_dirs()` now merges profile + global dirs to match `effective_dotfiles` behavior
+- `KeepLocal` conflict resolution now clears conflict state (no longer re-prompts on every sync)
+
+### Changed
+
+- `detect_conflict` takes pre-computed hashes so the local file is read once per sync instead of twice
+- Extracted `backup_and_write_dotfile` helper to dedupe backup+write logic in `decrypt_from_repo`
+
 ## [1.11.9] - 2026-04-07
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tether"
-version = "1.11.9"
+version = "1.11.10"
 edition = "2021"
 authors = ["Paddo Tech"]
 description = "Sync your development environment across machines automatically"

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -8,6 +8,7 @@ use crate::sync::{
     import_packages, sync_packages, GitBackend, MachineState, SyncEngine, SyncState,
 };
 use anyhow::Result;
+use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -746,87 +747,104 @@ pub fn decrypt_from_repo(
 
                         let last_synced_hash = state.files.get(&file).map(|f| f.hash.as_str());
 
-                        // Check for conflict
-                        if let Some(conflict) =
-                            detect_conflict(&file, &local_file, &plaintext, last_synced_hash)
-                        {
-                            if interactive {
-                                // Interactive mode: prompt user
-                                conflict.show_diff()?;
-                                let resolution = conflict.prompt_resolution()?;
+                        // First-time sync for create_if_missing files: remote wins.
+                        // This handles the case where an app creates a default file
+                        // (e.g. Claude Code writes `{}` to settings.json on startup)
+                        // before tether runs — that default shouldn't block the
+                        // synced content from being applied.
+                        let first_sync = last_synced_hash.is_none() && create_if_missing;
 
-                                match resolution {
-                                    ConflictResolution::KeepLocal => {}
-                                    ConflictResolution::UseRemote => {
-                                        // Backup before overwriting
-                                        if local_file.exists() {
-                                            if backup_dir.is_none() {
-                                                backup_dir = Some(create_backup_dir()?);
+                        if !first_sync {
+                            // Normal sync: check for conflict
+                            if let Some(conflict) =
+                                detect_conflict(&file, &local_file, &plaintext, last_synced_hash)
+                            {
+                                if interactive {
+                                    conflict.show_diff()?;
+                                    let resolution = conflict.prompt_resolution()?;
+
+                                    match resolution {
+                                        ConflictResolution::KeepLocal => {}
+                                        ConflictResolution::UseRemote => {
+                                            if local_file.exists() {
+                                                if backup_dir.is_none() {
+                                                    backup_dir = Some(create_backup_dir()?);
+                                                }
+                                                backup_file(
+                                                    backup_dir.as_ref().unwrap(),
+                                                    "dotfiles",
+                                                    &file,
+                                                    &local_file,
+                                                )?;
                                             }
-                                            backup_file(
-                                                backup_dir.as_ref().unwrap(),
-                                                "dotfiles",
-                                                &file,
-                                                &local_file,
-                                            )?;
+                                            write_decrypted(&local_file, &plaintext)?;
+                                            #[cfg(unix)]
+                                            preserve_executable_bit(&enc_file, &local_file);
+                                            conflict_state.remove_conflict(&file);
                                         }
-                                        write_decrypted(&local_file, &plaintext)?;
-                                        #[cfg(unix)]
-                                        preserve_executable_bit(&enc_file, &local_file);
-                                        conflict_state.remove_conflict(&file);
+                                        ConflictResolution::Merged => {
+                                            conflict.launch_merge_tool(&config.merge, home)?;
+                                            conflict_state.remove_conflict(&file);
+                                        }
+                                        ConflictResolution::Skip => {
+                                            new_conflicts.push((
+                                                file.to_string(),
+                                                conflict.local_hash.clone(),
+                                                conflict.remote_hash.clone(),
+                                            ));
+                                        }
                                     }
-                                    ConflictResolution::Merged => {
-                                        conflict.launch_merge_tool(&config.merge, home)?;
-                                        conflict_state.remove_conflict(&file);
-                                    }
-                                    ConflictResolution::Skip => {
-                                        new_conflicts.push((
-                                            file.to_string(),
-                                            conflict.local_hash.clone(),
-                                            conflict.remote_hash.clone(),
-                                        ));
-                                    }
+                                    continue;
+                                } else {
+                                    Output::warning(&format!(
+                                        "  {} (conflict - skipped)",
+                                        file
+                                    ));
+                                    new_conflicts.push((
+                                        file.to_string(),
+                                        conflict.local_hash.clone(),
+                                        conflict.remote_hash.clone(),
+                                    ));
+                                    continue;
                                 }
-                            } else {
-                                // Non-interactive (daemon): save conflict for later
-                                Output::warning(&format!("  {} (conflict - skipped)", file));
-                                new_conflicts.push((
-                                    file.to_string(),
-                                    conflict.local_hash.clone(),
-                                    conflict.remote_hash.clone(),
-                                ));
                             }
-                        } else {
-                            // No true conflict - but preserve local-only changes
-                            let remote_hash = crate::sha256_hex(&plaintext);
-                            let local_hash = std::fs::read(&local_file)
-                                .ok()
-                                .map(|c| crate::sha256_hex(&c));
-
-                            // Only write if local unchanged from last sync AND remote differs
-                            let local_unchanged = local_hash.as_deref() == last_synced_hash;
-                            if local_unchanged && local_hash.as_ref() != Some(&remote_hash) {
-                                // Backup before overwriting
-                                if local_file.exists() {
-                                    if backup_dir.is_none() {
-                                        backup_dir = Some(create_backup_dir()?);
-                                    }
-                                    backup_file(
-                                        backup_dir.as_ref().unwrap(),
-                                        "dotfiles",
-                                        &file,
-                                        &local_file,
-                                    )?;
-                                }
-                                if let Some(parent) = local_file.parent() {
-                                    std::fs::create_dir_all(parent)?;
-                                }
-                                write_decrypted(&local_file, &plaintext)?;
-                                #[cfg(unix)]
-                                preserve_executable_bit(&enc_file, &local_file);
-                            }
-                            conflict_state.remove_conflict(&file);
                         }
+
+                        // Apply remote content if local is unchanged or this is a first sync
+                        let remote_hash = format!("{:x}", Sha256::digest(&plaintext));
+                        let local_hash = std::fs::read(&local_file)
+                            .ok()
+                            .map(|c| format!("{:x}", Sha256::digest(&c)));
+
+                        let should_write = if first_sync {
+                            // First sync: write unless local already matches remote
+                            local_hash.as_ref() != Some(&remote_hash)
+                        } else {
+                            // Normal sync: only write if local unchanged from last sync
+                            let local_unchanged = local_hash.as_deref() == last_synced_hash;
+                            local_unchanged && local_hash.as_ref() != Some(&remote_hash)
+                        };
+
+                        if should_write {
+                            if local_file.exists() {
+                                if backup_dir.is_none() {
+                                    backup_dir = Some(create_backup_dir()?);
+                                }
+                                backup_file(
+                                    backup_dir.as_ref().unwrap(),
+                                    "dotfiles",
+                                    &file,
+                                    &local_file,
+                                )?;
+                            }
+                            if let Some(parent) = local_file.parent() {
+                                std::fs::create_dir_all(parent)?;
+                            }
+                            write_decrypted(&local_file, &plaintext)?;
+                            #[cfg(unix)]
+                            preserve_executable_bit(&enc_file, &local_file);
+                        }
+                        conflict_state.remove_conflict(&file);
                     }
                     Err(e) => {
                         Output::warning(&format!("  {} (failed to decrypt: {})", file, e));

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -8,7 +8,6 @@ use crate::sync::{
     import_packages, sync_packages, GitBackend, MachineState, SyncEngine, SyncState,
 };
 use anyhow::Result;
-use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -813,10 +812,10 @@ pub fn decrypt_from_repo(
                         }
 
                         // Apply remote content if local is unchanged or this is a first sync
-                        let remote_hash = format!("{:x}", Sha256::digest(&plaintext));
+                        let remote_hash = crate::sha256_hex(&plaintext);
                         let local_hash = std::fs::read(&local_file)
                             .ok()
-                            .map(|c| format!("{:x}", Sha256::digest(&c)));
+                            .map(|c| crate::sha256_hex(&c));
 
                         let should_write = if first_sync {
                             // First sync: write unless local already matches remote

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -654,6 +654,32 @@ fn write_decrypted(path: &Path, contents: &[u8]) -> Result<()> {
     crate::security::write_owner_only(path, contents)
 }
 
+/// Back up an existing dotfile (if present), ensure parent dir exists,
+/// write the decrypted content, and preserve the executable bit from the
+/// encrypted source file.
+fn backup_and_write_dotfile(
+    backup_dir: &mut Option<PathBuf>,
+    file: &str,
+    local_file: &Path,
+    enc_file: &Path,
+    plaintext: &[u8],
+) -> Result<()> {
+    use crate::sync::{backup_file, create_backup_dir};
+    if local_file.exists() {
+        if backup_dir.is_none() {
+            *backup_dir = Some(create_backup_dir()?);
+        }
+        backup_file(backup_dir.as_ref().unwrap(), "dotfiles", file, local_file)?;
+    }
+    if let Some(parent) = local_file.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    write_decrypted(local_file, plaintext)?;
+    #[cfg(unix)]
+    preserve_executable_bit(enc_file, local_file);
+    Ok(())
+}
+
 pub fn decrypt_from_repo(
     config: &Config,
     sync_path: &Path,
@@ -662,9 +688,7 @@ pub fn decrypt_from_repo(
     machine_state: &MachineState,
     interactive: bool,
 ) -> Result<()> {
-    use crate::sync::{
-        backup_file, create_backup_dir, detect_conflict, ConflictResolution, ConflictState,
-    };
+    use crate::sync::{detect_conflict, ConflictResolution, ConflictState};
 
     let key = crate::security::get_encryption_key()?;
     let dotfiles_dir = sync_path.join("dotfiles");
@@ -747,100 +771,88 @@ pub fn decrypt_from_repo(
                         let last_synced_hash = state.files.get(&file).map(|f| f.hash.as_str());
 
                         // First-time sync for create_if_missing files: remote wins.
-                        // This handles the case where an app creates a default file
-                        // (e.g. Claude Code writes `{}` to settings.json on startup)
-                        // before tether runs — that default shouldn't block the
-                        // synced content from being applied.
+                        // Handles apps that create defaults (e.g. Claude Code writes
+                        // `{}` to settings.json) before tether has a chance to sync.
                         let first_sync = last_synced_hash.is_none() && create_if_missing;
 
-                        if !first_sync {
-                            // Normal sync: check for conflict
-                            if let Some(conflict) =
-                                detect_conflict(&file, &local_file, &plaintext, last_synced_hash)
-                            {
-                                if interactive {
-                                    conflict.show_diff()?;
-                                    let resolution = conflict.prompt_resolution()?;
+                        let local_content = std::fs::read(&local_file).ok();
+                        let local_hash = local_content.as_ref().map(|c| crate::sha256_hex(c));
+                        let remote_hash = crate::sha256_hex(&plaintext);
 
-                                    match resolution {
-                                        ConflictResolution::KeepLocal => {
-                                            conflict_state.remove_conflict(&file);
-                                        }
-                                        ConflictResolution::UseRemote => {
-                                            if local_file.exists() {
-                                                if backup_dir.is_none() {
-                                                    backup_dir = Some(create_backup_dir()?);
-                                                }
-                                                backup_file(
-                                                    backup_dir.as_ref().unwrap(),
-                                                    "dotfiles",
+                        if !first_sync {
+                            if let (Some(lc), Some(lh)) =
+                                (local_content.as_ref(), local_hash.as_ref())
+                            {
+                                if let Some(conflict) = detect_conflict(
+                                    &file,
+                                    lc,
+                                    lh,
+                                    &plaintext,
+                                    &remote_hash,
+                                    last_synced_hash,
+                                ) {
+                                    if interactive {
+                                        conflict.show_diff()?;
+                                        let resolution = conflict.prompt_resolution()?;
+
+                                        match resolution {
+                                            ConflictResolution::KeepLocal => {
+                                                conflict_state.remove_conflict(&file);
+                                            }
+                                            ConflictResolution::UseRemote => {
+                                                backup_and_write_dotfile(
+                                                    &mut backup_dir,
                                                     &file,
                                                     &local_file,
+                                                    &enc_file,
+                                                    &plaintext,
                                                 )?;
+                                                conflict_state.remove_conflict(&file);
                                             }
-                                            write_decrypted(&local_file, &plaintext)?;
-                                            #[cfg(unix)]
-                                            preserve_executable_bit(&enc_file, &local_file);
-                                            conflict_state.remove_conflict(&file);
+                                            ConflictResolution::Merged => {
+                                                conflict.launch_merge_tool(&config.merge, home)?;
+                                                conflict_state.remove_conflict(&file);
+                                            }
+                                            ConflictResolution::Skip => {
+                                                new_conflicts.push((
+                                                    file.to_string(),
+                                                    conflict.local_hash.clone(),
+                                                    conflict.remote_hash.clone(),
+                                                ));
+                                            }
                                         }
-                                        ConflictResolution::Merged => {
-                                            conflict.launch_merge_tool(&config.merge, home)?;
-                                            conflict_state.remove_conflict(&file);
-                                        }
-                                        ConflictResolution::Skip => {
-                                            new_conflicts.push((
-                                                file.to_string(),
-                                                conflict.local_hash.clone(),
-                                                conflict.remote_hash.clone(),
-                                            ));
-                                        }
+                                        continue;
+                                    } else {
+                                        Output::warning(&format!(
+                                            "  {} (conflict - skipped)",
+                                            file
+                                        ));
+                                        new_conflicts.push((
+                                            file.to_string(),
+                                            conflict.local_hash.clone(),
+                                            conflict.remote_hash.clone(),
+                                        ));
+                                        continue;
                                     }
-                                    continue;
-                                } else {
-                                    Output::warning(&format!("  {} (conflict - skipped)", file));
-                                    new_conflicts.push((
-                                        file.to_string(),
-                                        conflict.local_hash.clone(),
-                                        conflict.remote_hash.clone(),
-                                    ));
-                                    continue;
                                 }
                             }
                         }
 
-                        // Apply remote content if local is unchanged or this is a first sync
-                        let remote_hash = crate::sha256_hex(&plaintext);
-                        let local_hash = std::fs::read(&local_file)
-                            .ok()
-                            .map(|c| crate::sha256_hex(&c));
-
                         let should_write = if first_sync {
-                            // First sync: write unless local already matches remote
                             local_hash.as_ref() != Some(&remote_hash)
                         } else {
-                            // Normal sync: only write if local unchanged from last sync
                             let local_unchanged = local_hash.as_deref() == last_synced_hash;
                             local_unchanged && local_hash.as_ref() != Some(&remote_hash)
                         };
 
                         if should_write {
-                            if local_file.exists() {
-                                if backup_dir.is_none() {
-                                    backup_dir = Some(create_backup_dir()?);
-                                }
-                                backup_file(
-                                    backup_dir.as_ref().unwrap(),
-                                    "dotfiles",
-                                    &file,
-                                    &local_file,
-                                )?;
-                            }
-                            if let Some(parent) = local_file.parent() {
-                                std::fs::create_dir_all(parent)?;
-                            }
-                            write_decrypted(&local_file, &plaintext)?;
-                            #[cfg(unix)]
-                            preserve_executable_bit(&enc_file, &local_file);
+                            backup_and_write_dotfile(
+                                &mut backup_dir,
+                                &file,
+                                &local_file,
+                                &enc_file,
+                                &plaintext,
+                            )?;
                         }
                         conflict_state.remove_conflict(&file);
                     }
@@ -1476,7 +1488,7 @@ pub fn sync_directories(
     let configs_dir = sync_path.join("configs");
     std::fs::create_dir_all(&configs_dir)?;
 
-    for dir_path in config.effective_dirs(machine_id) {
+    for dir_path in &config.effective_dirs(machine_id) {
         // Validate path is safe (security: prevents path traversal via synced config)
         if !crate::config::is_safe_dotfile_path(dir_path) {
             Output::warning(&format!("  {} (unsafe path, skipping)", dir_path));

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -764,7 +764,9 @@ pub fn decrypt_from_repo(
                                     let resolution = conflict.prompt_resolution()?;
 
                                     match resolution {
-                                        ConflictResolution::KeepLocal => {}
+                                        ConflictResolution::KeepLocal => {
+                                            conflict_state.remove_conflict(&file);
+                                        }
                                         ConflictResolution::UseRemote => {
                                             if local_file.exists() {
                                                 if backup_dir.is_none() {

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -797,10 +797,7 @@ pub fn decrypt_from_repo(
                                     }
                                     continue;
                                 } else {
-                                    Output::warning(&format!(
-                                        "  {} (conflict - skipped)",
-                                        file
-                                    ));
+                                    Output::warning(&format!("  {} (conflict - skipped)", file));
                                     new_conflicts.push((
                                         file.to_string(),
                                         conflict.local_hash.clone(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -708,11 +708,20 @@ impl Config {
     pub fn effective_dotfiles(&self, machine_id: &str) -> Vec<DotfileEntry> {
         if let Some(profile) = self.machine_profile(machine_id) {
             if !profile.dotfiles.is_empty() {
-                return profile
+                let mut entries: Vec<DotfileEntry> = profile
                     .dotfiles
                     .iter()
                     .map(|e| e.to_dotfile_entry())
                     .collect();
+                // Merge global dotfiles that aren't already in the profile list
+                let profile_paths: std::collections::HashSet<String> =
+                    entries.iter().map(|e| e.path().to_string()).collect();
+                for global in &self.dotfiles.files {
+                    if !profile_paths.contains(global.path()) {
+                        entries.push(global.clone());
+                    }
+                }
+                return entries;
             }
         }
         self.dotfiles.files.clone()
@@ -1383,7 +1392,9 @@ files = []
             .insert("my-server".to_string(), "server".to_string());
 
         let files = config.effective_dotfiles("my-server");
-        assert_eq!(files.len(), 1);
+        // Profile dotfiles are merged with global — .zshrc is in both so no duplicate
+        assert_eq!(files.len(), config.dotfiles.files.len());
+        // Profile entry comes first
         assert_eq!(files[0].path(), ".zshrc");
 
         // Unassigned machines get "dev" profile (which may or may not exist)
@@ -1495,8 +1506,8 @@ packages = ["brew"]
         assert_eq!(profile.dotfiles.len(), 1);
         assert_eq!(profile.packages, vec!["brew"]);
 
-        // Helpers work
-        assert_eq!(parsed.effective_dotfiles("my-server").len(), 1);
+        // Helpers work — profile dotfiles merge with global (profile has .zshrc, global adds .gitconfig)
+        assert_eq!(parsed.effective_dotfiles("my-server").len(), 2);
         assert!(!parsed.is_manager_enabled("my-server", "npm"));
         assert!(parsed.is_manager_enabled("my-server", "brew"));
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -713,11 +713,8 @@ impl Config {
                     .iter()
                     .map(|e| e.to_dotfile_entry())
                     .collect();
-                // Merge global dotfiles that aren't already in the profile list
-                let profile_paths: std::collections::HashSet<String> =
-                    entries.iter().map(|e| e.path().to_string()).collect();
                 for global in &self.dotfiles.files {
-                    if !profile_paths.contains(global.path()) {
+                    if !entries.iter().any(|e| e.path() == global.path()) {
                         entries.push(global.clone());
                     }
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -734,14 +734,21 @@ impl Config {
         }
     }
 
-    /// Get effective dirs for a machine (profile takes priority, then global)
-    pub fn effective_dirs(&self, machine_id: &str) -> &[String] {
+    /// Get effective dirs for a machine. Profile dirs merge with global dirs;
+    /// profile entries take priority on duplicates.
+    pub fn effective_dirs(&self, machine_id: &str) -> Vec<String> {
         if let Some(profile) = self.machine_profile(machine_id) {
             if !profile.dirs.is_empty() {
-                return &profile.dirs;
+                let mut dirs = profile.dirs.clone();
+                for global in &self.dotfiles.dirs {
+                    if !dirs.contains(global) {
+                        dirs.push(global.clone());
+                    }
+                }
+                return dirs;
             }
         }
-        &self.dotfiles.dirs
+        self.dotfiles.dirs.clone()
     }
 
     /// Check if a package manager is enabled for a machine.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1404,6 +1404,56 @@ files = []
     }
 
     #[test]
+    fn test_effective_dotfiles_profile_overrides_global() {
+        let mut config = Config::default();
+        // Global has .zshrc with create_if_missing=false (from default)
+        // Profile has .zshrc with create_if_missing=true — profile should win
+        config.profiles.insert(
+            "server".to_string(),
+            ProfileConfig {
+                dotfiles: vec![ProfileDotfileEntry::WithOptions {
+                    path: ".zshrc".to_string(),
+                    shared: false,
+                    create_if_missing: true,
+                }],
+                dirs: vec![],
+                packages: vec![],
+            },
+        );
+        config
+            .machine_profiles
+            .insert("my-server".to_string(), "server".to_string());
+
+        let files = config.effective_dotfiles("my-server");
+        let zshrc = files.iter().find(|e| e.path() == ".zshrc").unwrap();
+        // Profile version takes priority (create_if_missing=true)
+        assert!(zshrc.create_if_missing());
+    }
+
+    #[test]
+    fn test_effective_dotfiles_disjoint_sets() {
+        let mut config = Config::default();
+        config.dotfiles.files = vec![DotfileEntry::Simple(".gitconfig".to_string())];
+        config.profiles.insert(
+            "server".to_string(),
+            ProfileConfig {
+                dotfiles: vec![ProfileDotfileEntry::Simple(".vimrc".to_string())],
+                dirs: vec![],
+                packages: vec![],
+            },
+        );
+        config
+            .machine_profiles
+            .insert("my-server".to_string(), "server".to_string());
+
+        let files = config.effective_dotfiles("my-server");
+        // Profile has .vimrc, global has .gitconfig — should get both
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0].path(), ".vimrc"); // profile first
+        assert_eq!(files[1].path(), ".gitconfig"); // global appended
+    }
+
+    #[test]
     fn test_is_manager_enabled_with_profile() {
         let mut config = Config::default();
         config.profiles.insert(

--- a/src/sync/conflict.rs
+++ b/src/sync/conflict.rs
@@ -223,33 +223,26 @@ fn diff_lines<'a>(old: &[&'a str], new: &[&'a str]) -> Vec<DiffLine<'a>> {
     result
 }
 
-/// Detect conflicts for a file
+/// Detect conflicts for a file. Caller supplies pre-computed hashes to avoid
+/// re-reading and re-hashing in the common non-conflict path.
 pub fn detect_conflict(
     file_path: &str,
-    local_path: &Path,
+    local_content: &[u8],
+    local_hash: &str,
     remote_content: &[u8],
+    remote_hash: &str,
     last_synced_hash: Option<&str>,
 ) -> Option<FileConflict> {
-    let local_content = match std::fs::read(local_path) {
-        Ok(c) => c,
-        Err(_) => return None, // Local doesn't exist, no conflict
-    };
-
-    let local_hash = crate::sha256_hex(&local_content);
-    let remote_hash = crate::sha256_hex(remote_content);
-
-    // No conflict if hashes match
     if local_hash == remote_hash {
         return None;
     }
 
-    // Check if it's a true conflict (both changed since last sync)
     let conflict = FileConflict {
         file_path: file_path.to_string(),
-        local_hash,
+        local_hash: local_hash.to_string(),
         last_synced_hash: last_synced_hash.map(|s| s.to_string()),
-        remote_hash,
-        local_content,
+        remote_hash: remote_hash.to_string(),
+        local_content: local_content.to_vec(),
         remote_content: remote_content.to_vec(),
     };
 
@@ -374,7 +367,6 @@ pub fn notify_deferred_casks(casks: &[String]) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
 
     // is_true_conflict tests
     #[test]
@@ -447,32 +439,20 @@ mod tests {
     // detect_conflict tests
     #[test]
     fn test_detect_conflict_returns_none_when_equal() {
-        let temp = TempDir::new().unwrap();
-        let local_path = temp.path().join(".zshrc");
         let content = b"same content";
-        std::fs::write(&local_path, content).unwrap();
-
-        let result = detect_conflict(".zshrc", &local_path, content, None);
+        let hash = crate::sha256_hex(content);
+        let result = detect_conflict(".zshrc", content, &hash, content, &hash, None);
         assert!(result.is_none());
     }
 
     #[test]
     fn test_detect_conflict_returns_none_when_differ_no_history() {
         // No sync history means local is authoritative — not a conflict.
-        let temp = TempDir::new().unwrap();
-        let local_path = temp.path().join(".zshrc");
-        std::fs::write(&local_path, b"local content").unwrap();
-
-        let result = detect_conflict(".zshrc", &local_path, b"remote content", None);
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_detect_conflict_returns_none_when_local_missing() {
-        let temp = TempDir::new().unwrap();
-        let local_path = temp.path().join("nonexistent");
-
-        let result = detect_conflict("nonexistent", &local_path, b"remote", None);
+        let local = b"local content";
+        let remote = b"remote content";
+        let local_hash = crate::sha256_hex(local);
+        let remote_hash = crate::sha256_hex(remote);
+        let result = detect_conflict(".zshrc", local, &local_hash, remote, &remote_hash, None);
         assert!(result.is_none());
     }
 

--- a/src/sync/conflict.rs
+++ b/src/sync/conflict.rs
@@ -466,13 +466,14 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_conflict_returns_some_when_differ_no_history() {
+    fn test_detect_conflict_returns_none_when_differ_no_history() {
+        // No sync history means local is authoritative — not a conflict.
         let temp = TempDir::new().unwrap();
         let local_path = temp.path().join(".zshrc");
         std::fs::write(&local_path, b"local content").unwrap();
 
         let result = detect_conflict(".zshrc", &local_path, b"remote content", None);
-        assert!(result.is_some());
+        assert!(result.is_none());
     }
 
     #[test]

--- a/src/sync/conflict.rs
+++ b/src/sync/conflict.rs
@@ -36,18 +36,9 @@ impl FileConflict {
     /// Check if there's actually a conflict (both sides changed since last sync)
     pub fn is_true_conflict(&self) -> bool {
         match &self.last_synced_hash {
-            Some(last) => {
-                // Both changed: local != last AND remote != last
-                self.local_hash != *last && self.remote_hash != *last
-            }
-            None => {
-                // No sync history — local is authoritative. The export step will
-                // push it to establish a baseline. Treating this as a conflict
-                // causes the file to be skipped in both import AND export (since
-                // the daemon can't resolve conflicts interactively), leaving the
-                // file stuck indefinitely.
-                false
-            }
+            Some(last) => self.local_hash != *last && self.remote_hash != *last,
+            // No sync history — local is authoritative; export establishes baseline
+            None => false,
         }
     }
 

--- a/src/sync/conflict.rs
+++ b/src/sync/conflict.rs
@@ -41,8 +41,12 @@ impl FileConflict {
                 self.local_hash != *last && self.remote_hash != *last
             }
             None => {
-                // No sync history - conflict if they differ
-                self.local_hash != self.remote_hash
+                // No sync history — local is authoritative. The export step will
+                // push it to establish a baseline. Treating this as a conflict
+                // causes the file to be skipped in both import AND export (since
+                // the daemon can't resolve conflicts interactively), leaving the
+                // file stuck indefinitely.
+                false
             }
         }
     }
@@ -422,7 +426,9 @@ mod tests {
     }
 
     #[test]
-    fn test_is_conflict_no_sync_history_different() {
+    fn test_no_conflict_no_sync_history_different() {
+        // No sync history means local is authoritative — not a conflict.
+        // The export step will push to establish a baseline.
         let conflict = FileConflict {
             file_path: ".zshrc".to_string(),
             local_hash: "aaa".to_string(),
@@ -431,7 +437,7 @@ mod tests {
             local_content: vec![],
             remote_content: vec![],
         };
-        assert!(conflict.is_true_conflict());
+        assert!(!conflict.is_true_conflict());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes four bugs that prevent dotfile sync from working correctly when files are added to the config or edited locally. Closes #7. Supersedes #6.

## Root Cause Analysis

### Bug 1: No-sync-history treated as conflict (`conflict.rs`)

When a dotfile has no sync history (`last_synced_hash` is `None`) and local differs from remote, `is_true_conflict()` returns `true`. In daemon mode (non-interactive), conflicts can't be resolved, so the file is skipped in both import AND export — stuck indefinitely.

**Fix:** When `last_synced_hash` is `None`, return `false` — local is authoritative and the export step will push to establish a baseline.

### Bug 2: Remote content not applied on first sync for `create_if_missing` files (`sync.rs`)

When a dotfile with `create_if_missing = true` is synced to a new machine, an app may create a default file (e.g. Claude Code writes `{}` to `settings.json`) before tether runs. Tether sees the locally-created default as a "local edit" and refuses to overwrite it with the remote version.

**Fix:** When `last_synced_hash` is `None` AND `create_if_missing` is `true`, bypass conflict detection entirely and let remote win. The local default is backed up before overwriting.

### Bug 3: Profile dotfiles override global dotfiles (`config.rs`)

`effective_dotfiles()` returns **only** profile dotfiles when a profile exists, silently excluding any dotfiles defined only in the global `[dotfiles].files` config.

**Fix:** Merge profile dotfiles with global dotfiles. Profile entries take priority for duplicates (same path).

### Bug 4: KeepLocal resolution doesn't clear conflict state (`sync.rs`)

When the user chooses "Keep Local" during interactive conflict resolution, the conflict isn't removed from state. It re-prompts on every subsequent sync.

**Fix:** Call `conflict_state.remove_conflict(&file)` in the `KeepLocal` branch.

## Combined first-sync behavior

| `create_if_missing` | `last_synced_hash` | Who wins |
|---|---|---|
| `true` | `None` | **Remote** — file was expected to come from remote (Bug 2 fix) |
| `false` | `None` | **Local** — file was already there, not a conflict (Bug 1 fix) |
| any | `Some(hash)` | Normal three-way conflict detection |

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — 216 tests pass
- [ ] Daemon correctly syncs new `create_if_missing` dotfiles on first run
- [ ] Profile dotfiles merge with global dotfiles (no silent drops)
- [ ] KeepLocal resolution clears conflict state and doesn't re-prompt