### PR TITLE
build: migrate release.yml to ushr + fastlane match

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,44 @@ permissions:
   contents: write
 
 env:
-  # Signing identity - must match certificate installed on runner
+  # Signing identity - codesign matches by name; cert is installed at runtime
+  # via fastlane match into a temporary keychain (see fastlane/Fastfile).
   SIGNING_IDENTITY: "Developer ID Application: Paddo Tech PTY LTD (D9Q57P9D3L)"
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install fastlane via bundler
+        run: |
+          export GEM_HOME="$HOME/.gem"
+          export PATH="$HOME/.gem/bin:$PATH"
+          gem list bundler -i || gem install bundler --user-install
+          bundle config set --local path "$HOME/.gem"
+          bundle install --jobs 4
+
+      - name: Stash App Store Connect API key on disk
+        run: |
+          mkdir -p "$RUNNER_TEMP/fastlane"
+          echo '${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}' \
+            > "$RUNNER_TEMP/fastlane/asc_api_key.json"
+
+      - name: Sync Developer ID certificate (fastlane match)
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APP_STORE_CONNECT_API_KEY_PATH: ${{ runner.temp }}/fastlane/asc_api_key.json
+          # Override org-level MATCH_GIT_URL (likely SSH) with HTTPS+token —
+          # ephemeral VMs don't have an SSH key for the match repo.
+          MATCH_GIT_URL: https://x-access-token:${{ secrets.FASTLANE_MATCH_TOKEN }}@github.com/paddo-tech/fastlane-match.git
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_KEYCHAIN_NAME: tether_match
+          MATCH_KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          export PATH="$HOME/.gem/bin:$PATH"
+          bundle exec fastlane mac sync_developer_id
 
       - name: Build release (Apple Silicon)
         run: cargo build --release --target aarch64-apple-darwin
@@ -54,7 +84,6 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
         run: |
-          # Notarize Apple Silicon binary
           cd target/aarch64-apple-darwin/release
           zip tether-arm64.zip tether
           xcrun notarytool submit tether-arm64.zip \
@@ -65,7 +94,6 @@ jobs:
           rm tether-arm64.zip
           cd -
 
-          # Notarize Intel binary
           cd target/x86_64-apple-darwin/release
           zip tether-x64.zip tether
           xcrun notarytool submit tether-x64.zip \
@@ -91,7 +119,6 @@ jobs:
         run: |
           VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          # Detect prerelease (contains -alpha, -beta, -rc)
           if [[ "$VERSION" =~ -alpha|-beta|-rc ]]; then
             echo "prerelease=true" >> $GITHUB_OUTPUT
           else
@@ -113,7 +140,6 @@ jobs:
       - name: Create tag
         if: steps.release_check.outputs.exists == 'false' && github.event.inputs.dry_run != 'true'
         run: |
-          # Only create tag if it doesn't exist
           if ! git ls-remote --tags origin | grep -q "refs/tags/v${{ steps.version.outputs.version }}$"; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -146,25 +172,18 @@ jobs:
           SHA_ARM=$(cat target/aarch64-apple-darwin/release/tether-aarch64-apple-darwin.tar.gz.sha256 | awk '{print $1}')
           SHA_X86=$(cat target/x86_64-apple-darwin/release/tether-x86_64-apple-darwin.tar.gz.sha256 | awk '{print $1}')
 
-          # Clone the tap repo
           rm -rf /tmp/homebrew-tap
           git clone https://x-access-token:${COMMITTER_TOKEN}@github.com/paddo-tech/homebrew-tap.git /tmp/homebrew-tap
           cd /tmp/homebrew-tap
 
-          # Determine formula file and class name
           if [ "$IS_PRERELEASE" = "true" ]; then
-            # Versioned formula for prereleases: tether-cli@1.1.0-beta.1.rb
             FORMULA_FILE="Formula/tether-cli@${VERSION}.rb"
-            # Convert version to valid Ruby class name: 1.1.0-beta.1 -> 110Beta1
-            # Remove dots, capitalize after hyphens, remove hyphens
             CLASS_NAME="TetherCliAT$(echo ${VERSION} | perl -pe 's/\.//g; s/-(.)/\u$1/g')"
           else
-            # Main formula for stable releases
             FORMULA_FILE="Formula/tether-cli.rb"
             CLASS_NAME="TetherCli"
           fi
 
-          # Generate formula
           printf '%s\n' \
             "class ${CLASS_NAME} < Formula" \
             '  desc "Sync dotfiles and packages across machines"' \
@@ -201,10 +220,17 @@ jobs:
             '  end' \
             'end' > "$FORMULA_FILE"
 
-          # Commit and push
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add "$FORMULA_FILE"
           git commit -m "tether-cli ${VERSION}"
           git push
 
+      - name: Cleanup match keychain
+        if: always()
+        env:
+          MATCH_KEYCHAIN_NAME: tether_match
+        run: |
+          export PATH="$HOME/.gem/bin:$PATH"
+          bundle exec fastlane mac cleanup_keychain || true
+          rm -f "$RUNNER_TEMP/fastlane/asc_api_key.json" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,19 +37,11 @@ jobs:
           bundle config set --local path "$HOME/.gem"
           bundle install --jobs 4
 
-      - name: Stash App Store Connect API key on disk
-        run: |
-          mkdir -p "$RUNNER_TEMP/fastlane"
-          echo '${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}' \
-            > "$RUNNER_TEMP/fastlane/asc_api_key.json"
-
       - name: Sync Developer ID certificate (fastlane match)
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APP_STORE_CONNECT_API_KEY_PATH: ${{ runner.temp }}/fastlane/asc_api_key.json
-          # Override org-level MATCH_GIT_URL (likely SSH) with HTTPS+token —
-          # ephemeral VMs don't have an SSH key for the match repo.
+          # HTTPS+token: ephemeral VMs have no SSH key for the match repo.
           MATCH_GIT_URL: https://x-access-token:${{ secrets.FASTLANE_MATCH_TOKEN }}@github.com/paddo-tech/fastlane-match.git
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_KEYCHAIN_NAME: tether_match
@@ -233,4 +225,3 @@ jobs:
         run: |
           export PATH="$HOME/.gem/bin:$PATH"
           bundle exec fastlane mac cleanup_keychain || true
-          rm -f "$RUNNER_TEMP/fastlane/asc_api_key.json" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,9 +70,22 @@ jobs:
           KC=$(security list-keychains -d user | tr -d ' "' | grep -i tether_match \
             || echo "$HOME/Library/Keychains/tether_match-db")
           security unlock-keychain -p "$MATCH_KEYCHAIN_PASSWORD" "$KC"
+
+          # Bare CI images lack the Developer ID intermediate, so the leaf can't
+          # chain to Apple's root and codesign rejects it as an invalid identity.
+          tmp=$(mktemp -d)
+          for url in \
+            https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer \
+            https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer \
+            https://www.apple.com/appleca/AppleIncRootCertificate.cer ; do
+            f="$tmp/$(basename "$url")"
+            curl -fsSL -o "$f" "$url" && security import "$f" -k "$KC" -A >/dev/null 2>&1 || true
+          done
+
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$MATCH_KEYCHAIN_PASSWORD" "$KC" >/dev/null 2>&1 || true
-          security find-identity -v -p codesigning "$KC"
+          echo "-- identities (incl invalid):"; security find-identity -p codesigning "$KC" || true
+          echo "-- valid identities:"; security find-identity -v -p codesigning "$KC" || true
 
           for bin in aarch64-apple-darwin x86_64-apple-darwin; do
             codesign --sign "$SIGNING_IDENTITY" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,18 +62,26 @@ jobs:
         run: cargo build --release --target x86_64-apple-darwin
 
       - name: Sign binaries
+        env:
+          MATCH_KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
-          codesign --sign "$SIGNING_IDENTITY" \
-            --options runtime \
-            --timestamp \
-            --force \
-            target/aarch64-apple-darwin/release/tether
+          # match installed the identity into a temporary keychain; make it
+          # searchable and mark the key usable by codesign without a UI prompt.
+          KC=$(security list-keychains -d user | tr -d ' "' | grep -i tether_match \
+            || echo "$HOME/Library/Keychains/tether_match-db")
+          security unlock-keychain -p "$MATCH_KEYCHAIN_PASSWORD" "$KC"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$MATCH_KEYCHAIN_PASSWORD" "$KC" >/dev/null 2>&1 || true
+          security find-identity -v -p codesigning "$KC"
 
-          codesign --sign "$SIGNING_IDENTITY" \
-            --options runtime \
-            --timestamp \
-            --force \
-            target/x86_64-apple-darwin/release/tether
+          for bin in aarch64-apple-darwin x86_64-apple-darwin; do
+            codesign --sign "$SIGNING_IDENTITY" \
+              --keychain "$KC" \
+              --options runtime \
+              --timestamp \
+              --force \
+              "target/$bin/release/tether"
+          done
 
       - name: Notarize binaries
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,11 @@ jobs:
           export PATH="$HOME/.gem/bin:$PATH"
           bundle exec fastlane mac sync_developer_id
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
       - name: Build release (Apple Silicon)
         run: cargo build --release --target aarch64-apple-darwin
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ website/dist/
 website/.astro/
 website/bun.lockb
 *.bun-build
+
+# Local fastlane secrets (MATCH_PASSWORD, KEYCHAIN_PASSWORD)
+.env.local

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,2 @@
+apple_id(ENV["APPLE_ID"])
+team_id(ENV["APPLE_TEAM_ID"])

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,39 @@
+default_platform(:mac)
+
+# tether is signed with a Developer ID Application certificate that lives in
+# fastlane match. Each release run installs the cert into a fresh temporary
+# keychain, codesign signs against it, then the keychain is destroyed. Fits
+# ephemeral runners (ushr's Tart VMs) where state must not persist.
+
+KEYCHAIN_NAME = ENV["MATCH_KEYCHAIN_NAME"] || "tether_match"
+KEYCHAIN_PASSWORD = ENV["MATCH_KEYCHAIN_PASSWORD"] || "tether_match_password"
+APP_IDENTIFIER = ENV["MATCH_APP_IDENTIFIER"] || "dev.paddo.tether-cli"
+
+platform :mac do
+  desc "Install the Developer ID Application certificate via match into a temp keychain"
+  lane :sync_developer_id do
+    create_keychain(
+      name: KEYCHAIN_NAME,
+      password: KEYCHAIN_PASSWORD,
+      default_keychain: true,
+      unlock: true,
+      timeout: 3600,
+      lock_when_sleeps: false,
+    )
+
+    match(
+      type: "developer_id",
+      app_identifier: APP_IDENTIFIER,
+      git_url: ENV["MATCH_GIT_URL"],
+      keychain_name: KEYCHAIN_NAME,
+      keychain_password: KEYCHAIN_PASSWORD,
+      readonly: true,
+      api_key_path: ENV["APP_STORE_CONNECT_API_KEY_PATH"],
+    )
+  end
+
+  desc "Delete the temporary match keychain"
+  lane :cleanup_keychain do
+    delete_keychain(name: KEYCHAIN_NAME) rescue UI.message("keychain already gone")
+  end
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,6 +31,8 @@ platform :mac do
       # The cert was imported with skip_certificate_matching, so its file name
       # is not a portal certificate id; skip the portal lookup at install time.
       skip_certificate_matching: true,
+      # Developer ID signs binaries, not app bundles, so there is no profile.
+      skip_provisioning_profiles: true,
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,7 +28,9 @@ platform :mac do
       keychain_name: KEYCHAIN_NAME,
       keychain_password: KEYCHAIN_PASSWORD,
       readonly: true,
-      api_key_path: ENV["APP_STORE_CONNECT_API_KEY_PATH"],
+      # The cert was imported with skip_certificate_matching, so its file name
+      # is not a portal certificate id; skip the portal lookup at install time.
+      skip_certificate_matching: true,
     )
   end
 


### PR DESCRIPTION
Migrates the release pipeline off the persistent self-hosted runner (which had the Developer ID cert pre-installed in its login keychain) onto ephemeral macOS runner VMs.

## Why
- The persistent runner was a single point of failure and kept the signing key in a long-lived keychain.
- Ephemeral VMs cannot have the cert pre-installed. Each run pulls it from a private fastlane match repo into a temporary keychain and deletes the keychain afterwards.

## What
- New `Gemfile`, `fastlane/Appfile`, `fastlane/Fastfile` with `sync_developer_id` and `cleanup_keychain` lanes.
- `release.yml` targets `[self-hosted, macOS, ARM64]`, installs fastlane via bundler, runs match before the existing codesign/notarize/release/Homebrew steps, and always cleans up.
- The cert was imported into match with `skip_certificate_matching`, so install skips the App Store Connect lookup too. Signing needs no API key; notarization still uses the Apple ID app password.
- `MATCH_GIT_URL` is an HTTPS+token URL because the VMs have no SSH key for the match repo.

## Secrets (repository level)
This repository is public and the organization is on the Free plan, so organization secrets do not apply. Required on the repository: `MATCH_PASSWORD`, `KEYCHAIN_PASSWORD`, `FASTLANE_MATCH_TOKEN` (PAT, Contents: Read on the match repo), `APPLE_ID`, `APPLE_TEAM_ID`, `APPLE_APP_PASSWORD`, `HOMEBREW_TAP_TOKEN`.

## Status
- [x] Developer ID cert and key imported into the match repo under `certs/developer_id_application/`
- [x] `MATCH_PASSWORD`, `KEYCHAIN_PASSWORD` set on the repository
- [ ] `FASTLANE_MATCH_TOKEN` set on the repository
- [ ] `workflow_dispatch` with `dry_run: true`
- [ ] Real release on the next version bump

https://claude.ai/code/session_01DQwemoce57wvK1b4mvJV6a