### PR TITLE
fix: generate random machine ids to prevent fleet state clobbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Onboarding a machine that shares a hostname with an existing machine no longer overwrites that machine's sync state — machine identity is now a random id rather than the hostname
+- `pnpm` failures now surface the real error text (pnpm writes errors to stdout, not stderr, so failures previously showed a blank reason)
+
+### Changed
+
+- New machines get a random machine id; existing machines keep their hostname-based id, so no migration runs on upgrade. A fleet that already contains two machines sharing a hostname is not auto-repaired — re-id one of them by removing its `~/.tether/state.json` and running `tether init` again
+
 ## [1.11.10] - 2026-04-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- New machines get a random machine id; existing machines keep their hostname-based id, so no migration runs on upgrade. A fleet that already contains two machines sharing a hostname is not auto-repaired — re-id one of them by removing its `~/.tether/state.json`, running `tether sync`, then `tether machines profile set <name>` (the new id starts on the default profile)
+- New machines get a random machine id; existing machines keep their hostname-based id, so no migration runs on upgrade. A fleet that already contains two machines sharing a hostname is not auto-repaired — on one of them run `tether machines rename <hostname> <new-name>`; the other machine recreates its own record on its next sync, with empty removed-package and ignore lists
+- Sync commits are authored with the machine hostname, so `tether history` stays readable for machines with random ids
 
 ## [1.11.10] - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Onboarding a machine that shares a hostname with an existing machine no longer overwrites that machine's sync state — machine identity is now a random id rather than the hostname
-- `pnpm` failures now surface the real error text (pnpm writes errors to stdout, not stderr, so failures previously showed a blank reason)
+- `pnpm` failures now surface the real error text (pnpm writes errors to stdout, not stderr, so failures previously showed a blank reason). Both streams are reported, so a Node warning on stderr cannot hide the error
 
 ### Changed
 
-- New machines get a random machine id; existing machines keep their hostname-based id, so no migration runs on upgrade. A fleet that already contains two machines sharing a hostname is not auto-repaired — re-id one of them by removing its `~/.tether/state.json` and running `tether init` again
+- New machines get a random machine id; existing machines keep their hostname-based id, so no migration runs on upgrade. A fleet that already contains two machines sharing a hostname is not auto-repaired — re-id one of them by removing its `~/.tether/state.json`, running `tether sync`, then `tether machines profile set <name>` (the new id starts on the default profile)
 
 ## [1.11.10] - 2026-04-08
 

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -1,7 +1,7 @@
 use crate::cli::{Output, Progress, Prompt};
 use crate::config::{Config, FeaturesConfig};
 use crate::github::GitHubCli;
-use crate::sync::{GitBackend, SyncEngine, SyncState};
+use crate::sync::{GitBackend, MachineState, SyncEngine, SyncState};
 use anyhow::Result;
 
 pub async fn run(repo: Option<&str>, no_daemon: bool, team_only: bool) -> Result<()> {
@@ -102,6 +102,8 @@ pub async fn run(repo: Option<&str>, no_daemon: bool, team_only: bool) -> Result
         std::fs::create_dir_all(sync_path.join("machines"))?;
 
         crate::sync::check_sync_format_version(&sync_path)?;
+
+        resolve_machine_identity(&sync_path)?;
 
         // Setup encryption if enabled
         if config.security.encrypt_dotfiles {
@@ -277,6 +279,86 @@ fn assign_profile_during_init(config: &mut Config) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Detect machine_id collisions before the first sync.
+///
+/// machine_id is derived from hostname, so two machines with the same hostname
+/// share a `machines/<id>.json` record. The new machine's first sync would
+/// overwrite the existing record with its (empty) local state and flag every
+/// package as removed. On a fresh onboard, if the id is already taken, ask
+/// whether this is the same machine or a new one and assign a unique id.
+fn resolve_machine_identity(sync_path: &std::path::Path) -> Result<()> {
+    // Established machines already have an identity — don't re-prompt on reinit.
+    if SyncState::state_path()?.exists() {
+        return Ok(());
+    }
+
+    let mut state = SyncState::load()?;
+    let candidate = state.machine_id.clone();
+
+    let existing = match MachineState::load_from_repo(sync_path, &candidate)? {
+        Some(m) => m,
+        None => return Ok(()),
+    };
+
+    let pkg_count: usize = existing.packages.values().map(Vec::len).sum();
+    Output::warning(&format!(
+        "A machine named '{}' already exists in your sync repo",
+        candidate
+    ));
+    Output::dim(&format!("  hostname:  {}", existing.hostname));
+    Output::dim(&format!(
+        "  last sync: {}",
+        existing
+            .last_sync
+            .with_timezone(&chrono::Local)
+            .format("%Y-%m-%d %H:%M")
+    ));
+    Output::dim(&format!("  packages:  {}", pkg_count));
+    Output::dim(&format!("  dotfiles:  {}", existing.dotfiles.len()));
+    println!();
+
+    let options = vec![
+        "This is a new machine (pick a different name)",
+        "This is the same machine being re-onboarded",
+    ];
+    // idx 1 = same machine: keep the existing id and its record untouched.
+    if Prompt::select("Is this the same machine, or a new one?", options, 0)? == 1 {
+        return Ok(());
+    }
+
+    let machines_dir = sync_path.join("machines");
+    let suggested = suggest_machine_id(&machines_dir, &candidate);
+    loop {
+        let name = Prompt::input("New machine name", Some(&suggested))?;
+        let name = name.trim();
+        // A machine id becomes a `machines/<id>.json` filename.
+        if !Config::is_safe_profile_name(name) {
+            Output::error(&format!("Invalid machine name: '{}'", name));
+            continue;
+        }
+        if machines_dir.join(format!("{}.json", name)).exists() {
+            Output::error(&format!("'{}' is already taken", name));
+            continue;
+        }
+        state.machine_id = name.to_string();
+        state.save()?;
+        Output::success(&format!("This machine will sync as '{}'", name));
+        return Ok(());
+    }
+}
+
+/// Suggest an unused machine id by appending a numeric suffix.
+fn suggest_machine_id(machines_dir: &std::path::Path, base: &str) -> String {
+    let mut n = 2;
+    loop {
+        let candidate = format!("{}-{}", base, n);
+        if !machines_dir.join(format!("{}.json", candidate)).exists() {
+            return candidate;
+        }
+        n += 1;
+    }
 }
 
 /// Try to load config from the synced repo (encrypted).

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -1,7 +1,7 @@
 use crate::cli::{Output, Progress, Prompt};
 use crate::config::{Config, FeaturesConfig};
 use crate::github::GitHubCli;
-use crate::sync::{GitBackend, MachineState, SyncEngine, SyncState};
+use crate::sync::{GitBackend, SyncEngine, SyncState};
 use anyhow::Result;
 
 pub async fn run(repo: Option<&str>, no_daemon: bool, team_only: bool) -> Result<()> {
@@ -102,8 +102,6 @@ pub async fn run(repo: Option<&str>, no_daemon: bool, team_only: bool) -> Result
         std::fs::create_dir_all(sync_path.join("machines"))?;
 
         crate::sync::check_sync_format_version(&sync_path)?;
-
-        resolve_machine_identity(&sync_path)?;
 
         // Setup encryption if enabled
         if config.security.encrypt_dotfiles {
@@ -279,86 +277,6 @@ fn assign_profile_during_init(config: &mut Config) -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Detect machine_id collisions before the first sync.
-///
-/// machine_id is derived from hostname, so two machines with the same hostname
-/// share a `machines/<id>.json` record. The new machine's first sync would
-/// overwrite the existing record with its (empty) local state and flag every
-/// package as removed. On a fresh onboard, if the id is already taken, ask
-/// whether this is the same machine or a new one and assign a unique id.
-fn resolve_machine_identity(sync_path: &std::path::Path) -> Result<()> {
-    // Established machines already have an identity — don't re-prompt on reinit.
-    if SyncState::state_path()?.exists() {
-        return Ok(());
-    }
-
-    let mut state = SyncState::load()?;
-    let candidate = state.machine_id.clone();
-
-    let existing = match MachineState::load_from_repo(sync_path, &candidate)? {
-        Some(m) => m,
-        None => return Ok(()),
-    };
-
-    let pkg_count: usize = existing.packages.values().map(Vec::len).sum();
-    Output::warning(&format!(
-        "A machine named '{}' already exists in your sync repo",
-        candidate
-    ));
-    Output::dim(&format!("  hostname:  {}", existing.hostname));
-    Output::dim(&format!(
-        "  last sync: {}",
-        existing
-            .last_sync
-            .with_timezone(&chrono::Local)
-            .format("%Y-%m-%d %H:%M")
-    ));
-    Output::dim(&format!("  packages:  {}", pkg_count));
-    Output::dim(&format!("  dotfiles:  {}", existing.dotfiles.len()));
-    println!();
-
-    let options = vec![
-        "This is a new machine (pick a different name)",
-        "This is the same machine being re-onboarded",
-    ];
-    // idx 1 = same machine: keep the existing id and its record untouched.
-    if Prompt::select("Is this the same machine, or a new one?", options, 0)? == 1 {
-        return Ok(());
-    }
-
-    let machines_dir = sync_path.join("machines");
-    let suggested = suggest_machine_id(&machines_dir, &candidate);
-    loop {
-        let name = Prompt::input("New machine name", Some(&suggested))?;
-        let name = name.trim();
-        // A machine id becomes a `machines/<id>.json` filename.
-        if !Config::is_safe_profile_name(name) {
-            Output::error(&format!("Invalid machine name: '{}'", name));
-            continue;
-        }
-        if machines_dir.join(format!("{}.json", name)).exists() {
-            Output::error(&format!("'{}' is already taken", name));
-            continue;
-        }
-        state.machine_id = name.to_string();
-        state.save()?;
-        Output::success(&format!("This machine will sync as '{}'", name));
-        return Ok(());
-    }
-}
-
-/// Suggest an unused machine id by appending a numeric suffix.
-fn suggest_machine_id(machines_dir: &std::path::Path, base: &str) -> String {
-    let mut n = 2;
-    loop {
-        let candidate = format!("{}-{}", base, n);
-        if !machines_dir.join(format!("{}.json", candidate)).exists() {
-            return candidate;
-        }
-        n += 1;
-    }
 }
 
 /// Try to load config from the synced repo (encrypted).

--- a/src/cli/commands/machines.rs
+++ b/src/cli/commands/machines.rs
@@ -190,7 +190,10 @@ pub async fn rename(old: &str, new: &str) -> Result<()> {
 
     // Commit and push
     let git = GitBackend::open(&sync_path)?;
-    git.commit(&format!("Rename machine {} to {}", old, new), new)?;
+    git.commit(
+        &format!("Rename machine {} to {}", old, new),
+        &crate::sync::local_hostname(),
+    )?;
     git.push()?;
 
     Output::success(&format!("Renamed machine '{}' to '{}'", old, new));
@@ -234,7 +237,10 @@ pub async fn remove(name: &str) -> Result<()> {
 
     // Commit and push
     let git = GitBackend::open(&sync_path)?;
-    git.commit(&format!("Remove machine {}", name), &state.machine_id)?;
+    git.commit(
+        &format!("Remove machine {}", name),
+        &crate::sync::local_hostname(),
+    )?;
     git.push()?;
 
     Output::success(&format!("Removed machine '{}'", name));

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -330,7 +330,7 @@ pub async fn run(dry_run: bool, _force: bool, rediscover: bool) -> Result<()> {
 
         if has_changes {
             let pb = Progress::spinner("Pushing changes...");
-            git.commit("Sync dotfiles and packages", &state.machine_id)?;
+            git.commit("Sync dotfiles and packages", &crate::sync::local_hostname())?;
             git.push()?;
             pb.finish_and_clear();
         }
@@ -369,7 +369,7 @@ pub async fn run(dry_run: bool, _force: bool, rediscover: bool) -> Result<()> {
                             }
                         }
 
-                        team_git.commit("Update team configs", &state.machine_id)?;
+                        team_git.commit("Update team configs", &crate::sync::local_hostname())?;
                         team_git.push()?;
                     }
                 }
@@ -2189,8 +2189,7 @@ async fn run_team_only_sync(config: &Config, dry_run: bool) -> Result<()> {
 
             // Push changes if we have write access
             if !team_config.read_only && team_git.has_changes()? {
-                let state = SyncState::load()?;
-                team_git.commit("Update team configs", &state.machine_id)?;
+                team_git.commit("Update team configs", &crate::sync::local_hostname())?;
                 team_git.push()?;
             }
         } else {

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -448,7 +448,7 @@ impl DaemonServer {
         let has_changes = git.has_changes()?;
         if has_changes {
             log::info!("Committing changes...");
-            git.commit("Auto-sync from daemon", &state.machine_id)?;
+            git.commit("Auto-sync from daemon", &crate::sync::local_hostname())?;
             git.push()?;
             log::info!("Sync complete - changes pushed");
         } else {
@@ -486,7 +486,7 @@ impl DaemonServer {
                                 }
                             }
                         }
-                        team_git.commit("Update team configs", &state.machine_id)?;
+                        team_git.commit("Update team configs", &crate::sync::local_hostname())?;
                         team_git.push()?;
                     }
                 }
@@ -545,8 +545,7 @@ impl DaemonServer {
 
             // Push changes if we have write access
             if !team_config.read_only && team_git.has_changes()? {
-                let state = SyncState::load()?;
-                team_git.commit("Update team configs", &state.machine_id)?;
+                team_git.commit("Update team configs", &crate::sync::local_hostname())?;
                 team_git.push()?;
             }
         }

--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -27,12 +27,12 @@ pub fn command_error_message(output: &std::process::Output) -> String {
 #[cfg(test)]
 mod tests {
     use super::command_error_message;
-    use std::process::{Command, Output};
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::{ExitStatus, Output};
 
     fn output(stderr: &[u8], stdout: &[u8]) -> Output {
-        let status = Command::new("true").status().unwrap();
         Output {
-            status,
+            status: ExitStatus::from_raw(0),
             stdout: stdout.to_vec(),
             stderr: stderr.to_vec(),
         }

--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -13,3 +13,49 @@ pub use manager::{PackageInfo, PackageManager};
 pub use npm::NpmManager;
 pub use pnpm::PnpmManager;
 pub use uv::UvManager;
+
+/// Some tools (pnpm) report failures on stdout, so surface both streams.
+pub fn command_error_message(output: &std::process::Output) -> String {
+    [&output.stderr, &output.stdout]
+        .iter()
+        .map(|bytes| String::from_utf8_lossy(bytes).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::command_error_message;
+    use std::process::{Command, Output};
+
+    fn output(stderr: &[u8], stdout: &[u8]) -> Output {
+        let status = Command::new("true").status().unwrap();
+        Output {
+            status,
+            stdout: stdout.to_vec(),
+            stderr: stderr.to_vec(),
+        }
+    }
+
+    #[test]
+    fn joins_trimmed_streams_stderr_first() {
+        assert_eq!(
+            command_error_message(&output(b"  warn  ", b" ERR_PNPM_X \n")),
+            "warn\nERR_PNPM_X"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_stdout_when_stderr_blank() {
+        assert_eq!(
+            command_error_message(&output(b"   \n", b"  ENOENT  ")),
+            "ENOENT"
+        );
+    }
+
+    #[test]
+    fn empty_when_both_blank() {
+        assert_eq!(command_error_message(&output(b"", b"  ")), "");
+    }
+}

--- a/src/packages/pnpm.rs
+++ b/src/packages/pnpm.rs
@@ -130,3 +130,23 @@ fn pnpm_error_message(stderr: &[u8], stdout: &[u8]) -> String {
     }
     String::from_utf8_lossy(stdout).trim().to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefers_trimmed_stderr() {
+        assert_eq!(pnpm_error_message(b"  boom  ", b"ignored"), "boom");
+    }
+
+    #[test]
+    fn falls_back_to_stdout_when_stderr_blank() {
+        assert_eq!(pnpm_error_message(b"   \n", b"  ENOENT  "), "ENOENT");
+    }
+
+    #[test]
+    fn empty_when_both_blank() {
+        assert_eq!(pnpm_error_message(b"", b"  "), "");
+    }
+}

--- a/src/packages/pnpm.rs
+++ b/src/packages/pnpm.rs
@@ -15,8 +15,10 @@ impl PnpmManager {
         let output = Command::new("pnpm").args(args).output().await?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("pnpm command failed: {}", stderr));
+            return Err(anyhow::anyhow!(
+                "pnpm command failed: {}",
+                pnpm_error_message(&output.stderr, &output.stdout)
+            ));
         }
 
         Ok(String::from_utf8(output.stdout)?)
@@ -93,8 +95,10 @@ impl PackageManager for PnpmManager {
         let output = Command::new("pnpm").args(["update", "-g"]).output().await?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("pnpm update failed: {}", stderr));
+            return Err(anyhow::anyhow!(
+                "pnpm update failed: {}",
+                pnpm_error_message(&output.stderr, &output.stdout)
+            ));
         }
 
         Ok(())
@@ -107,10 +111,22 @@ impl PackageManager for PnpmManager {
             .await?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("pnpm remove failed: {}", stderr));
+            return Err(anyhow::anyhow!(
+                "pnpm remove failed: {}",
+                pnpm_error_message(&output.stderr, &output.stdout)
+            ));
         }
 
         Ok(())
     }
+}
+
+/// pnpm writes failures to stdout, not stderr — fall back when stderr is empty.
+fn pnpm_error_message(stderr: &[u8], stdout: &[u8]) -> String {
+    let err = String::from_utf8_lossy(stderr);
+    let trimmed = err.trim();
+    if !trimmed.is_empty() {
+        return trimmed.to_string();
+    }
+    String::from_utf8_lossy(stdout).trim().to_string()
 }

--- a/src/packages/pnpm.rs
+++ b/src/packages/pnpm.rs
@@ -1,4 +1,4 @@
-use super::{PackageInfo, PackageManager};
+use super::{command_error_message, PackageInfo, PackageManager};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::Value;
@@ -17,7 +17,7 @@ impl PnpmManager {
         if !output.status.success() {
             return Err(anyhow::anyhow!(
                 "pnpm command failed: {}",
-                pnpm_error_message(&output.stderr, &output.stdout)
+                command_error_message(&output)
             ));
         }
 
@@ -97,7 +97,7 @@ impl PackageManager for PnpmManager {
         if !output.status.success() {
             return Err(anyhow::anyhow!(
                 "pnpm update failed: {}",
-                pnpm_error_message(&output.stderr, &output.stdout)
+                command_error_message(&output)
             ));
         }
 
@@ -113,40 +113,10 @@ impl PackageManager for PnpmManager {
         if !output.status.success() {
             return Err(anyhow::anyhow!(
                 "pnpm remove failed: {}",
-                pnpm_error_message(&output.stderr, &output.stdout)
+                command_error_message(&output)
             ));
         }
 
         Ok(())
-    }
-}
-
-/// pnpm writes failures to stdout, not stderr — fall back when stderr is empty.
-fn pnpm_error_message(stderr: &[u8], stdout: &[u8]) -> String {
-    let err = String::from_utf8_lossy(stderr);
-    let trimmed = err.trim();
-    if !trimmed.is_empty() {
-        return trimmed.to_string();
-    }
-    String::from_utf8_lossy(stdout).trim().to_string()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn prefers_trimmed_stderr() {
-        assert_eq!(pnpm_error_message(b"  boom  ", b"ignored"), "boom");
-    }
-
-    #[test]
-    fn falls_back_to_stdout_when_stderr_blank() {
-        assert_eq!(pnpm_error_message(b"   \n", b"  ENOENT  "), "ENOENT");
-    }
-
-    #[test]
-    fn empty_when_both_blank() {
-        assert_eq!(pnpm_error_message(b"", b"  "), "");
     }
 }

--- a/src/security/encryption.rs
+++ b/src/security/encryption.rs
@@ -14,7 +14,7 @@ pub fn generate_key() -> [u8; KEY_SIZE] {
     key
 }
 
-/// Generate a random 12-character hex id.
+/// Generate a random hex id.
 pub fn random_hex_id() -> String {
     let mut bytes = [0u8; 6];
     OsRng.fill_bytes(&mut bytes);

--- a/src/security/encryption.rs
+++ b/src/security/encryption.rs
@@ -14,6 +14,13 @@ pub fn generate_key() -> [u8; KEY_SIZE] {
     key
 }
 
+/// Generate a random 12-character hex id.
+pub fn random_hex_id() -> String {
+    let mut bytes = [0u8; 6];
+    OsRng.fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
 /// Encrypt data using AES-256-GCM
 /// Format: [nonce (12 bytes)][ciphertext + auth tag]
 pub fn encrypt(plaintext: &[u8], key: &[u8]) -> Result<Vec<u8>> {
@@ -94,6 +101,16 @@ mod tests {
         assert_eq!(key1.len(), KEY_SIZE);
         assert_eq!(key2.len(), KEY_SIZE);
         assert_ne!(key1, key2); // Keys should be random
+    }
+
+    #[test]
+    fn test_random_hex_id() {
+        let id1 = random_hex_id();
+        let id2 = random_hex_id();
+
+        assert_eq!(id1.len(), 12);
+        assert!(id1.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(id1, id2);
     }
 
     #[test]

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -58,7 +58,7 @@ pub fn write_owner_only(path: &Path, data: &[u8]) -> Result<()> {
     Ok(())
 }
 
-pub use encryption::{decrypt, encrypt, generate_key};
+pub use encryption::{decrypt, encrypt, generate_key, random_hex_id};
 pub use keychain::{
     clear_cached_key, get_encryption_key, has_encryption_key, is_unlocked,
     store_encryption_key_with_passphrase, unlock_with_passphrase,

--- a/src/sync/git.rs
+++ b/src/sync/git.rs
@@ -67,7 +67,7 @@ impl GitBackend {
         })
     }
 
-    pub fn commit(&self, message: &str, machine_id: &str) -> Result<()> {
+    pub fn commit(&self, message: &str, author: &str) -> Result<()> {
         let repo = Repository::open(&self.repo_path)?;
         let mut index = repo.index()?;
         index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)?;
@@ -76,7 +76,7 @@ impl GitBackend {
         let oid = index.write_tree()?;
         let tree = repo.find_tree(oid)?;
 
-        let sig = Signature::now(machine_id, "tether@local")?;
+        let sig = Signature::now(author, "tether@local")?;
 
         // Check if this is the first commit
         if self.has_commits() {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -26,7 +26,7 @@ pub use layers::{
 };
 pub use merge::{detect_file_type, merge_files, FileType};
 pub use packages::{import_packages, sync_packages};
-pub use state::{CheckoutInfo, FileState, MachineState, SyncState};
+pub use state::{local_hostname, CheckoutInfo, FileState, MachineState, SyncState};
 pub use team::{
     default_local_patterns, discover_symlinkable_dirs, extract_org_from_url,
     extract_team_name_from_url, find_team_for_project, get_project_org, glob_match, is_local_file,

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -278,11 +278,11 @@ impl SyncState {
         }
     }
 
+    /// A random id, not the hostname — hostnames collide across machines, and a
+    /// collision makes one machine's sync overwrite another's `machines/<id>.json`
+    /// record. The human-readable hostname lives on `MachineState` as metadata.
     fn generate_machine_id() -> String {
-        hostname::get()
-            .ok()
-            .and_then(|h| h.into_string().ok())
-            .unwrap_or_else(|| "unknown".to_string())
+        crate::security::random_hex_id()
     }
 
     pub fn update_file(&mut self, path: &str, hash: String) {

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -252,7 +252,10 @@ impl SyncState {
     pub fn load() -> Result<Self> {
         let path = Self::state_path()?;
         if !path.exists() {
-            return Ok(Self::new());
+            // The random machine id must survive across calls, so persist on first load.
+            let state = Self::new();
+            state.save()?;
+            return Ok(state);
         }
         let content = std::fs::read_to_string(path)?;
         Ok(serde_json::from_str(&content)?)
@@ -266,7 +269,8 @@ impl SyncState {
 
     fn new() -> Self {
         Self {
-            machine_id: Self::generate_machine_id(),
+            // Random, not the hostname: hostnames are not unique across a fleet.
+            machine_id: crate::security::random_hex_id(),
             last_sync: Utc::now(),
             files: HashMap::new(),
             packages: HashMap::new(),
@@ -276,13 +280,6 @@ impl SyncState {
             deferred_casks_hash: None,
             dismissed_imports: std::collections::HashSet::new(),
         }
-    }
-
-    /// A random id, not the hostname — hostnames collide across machines, and a
-    /// collision makes one machine's sync overwrite another's `machines/<id>.json`
-    /// record. The human-readable hostname lives on `MachineState` as metadata.
-    fn generate_machine_id() -> String {
-        crate::security::random_hex_id()
     }
 
     pub fn update_file(&mut self, path: &str, hash: String) {

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -99,16 +99,18 @@ impl Default for MachineState {
     }
 }
 
+pub fn local_hostname() -> String {
+    hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
 impl MachineState {
     pub fn new(machine_id: &str) -> Self {
-        let hostname = hostname::get()
-            .ok()
-            .and_then(|h| h.into_string().ok())
-            .unwrap_or_else(|| "unknown".to_string());
-
         Self {
             machine_id: machine_id.to_string(),
-            hostname,
+            hostname: local_hostname(),
             last_sync: Utc::now(),
             os_version: String::new(),
             cli_version: env!("CARGO_PKG_VERSION").to_string(),


### PR DESCRIPTION
## Summary

- `machine_id` was derived from the hostname, so two machines sharing a hostname also shared a `machines/<id>.json` record. The second machine's first sync overwrote the first's state with empty local data, and removed-package detection then flagged the whole fleet's packages as deliberately removed.
- `machine_id` is now a random hex id minted once per machine. Collisions are no longer possible; the hostname is purely display metadata on `MachineState`. Existing machines keep their hostname-based id (already persisted in `state.json`), so there is no migration.
- Re-onboarding a machine now produces a fresh id (a harmless "ghost" record removable via `tether machines remove`) rather than risking a clobber.
- Also surfaces pnpm errors written to stdout: pnpm exits non-zero with its message on stdout, so failures previously showed a blank reason.

## Test plan

- [ ] Fresh `tether init` mints a random `machine_id`; a second machine with the same hostname gets a distinct id and does not overwrite the first's record
- [ ] An already-onboarded machine keeps its existing id across syncs and reinit
- [ ] `tether machines list` / `remove` still work with the new ids
- [ ] A failing pnpm command surfaces the real error text instead of a blank message