### PR TITLE
feat: package manifest history and rollback in the dashboard

### DIFF
--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -10,6 +10,7 @@ mod machines;
 mod packages;
 mod resolve;
 mod restore;
+mod rollback;
 mod status;
 pub mod sync;
 mod team;
@@ -154,6 +155,23 @@ pub enum Commands {
         /// Maximum number of entries to show
         #[arg(short, long, default_value = "20")]
         limit: usize,
+    },
+
+    /// Roll back synced state to an earlier point
+    Rollback {
+        #[command(subcommand)]
+        action: RollbackAction,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum RollbackAction {
+    /// Roll back a package manager's installed set to a manifest commit
+    Packages {
+        /// Manager key (npm, pnpm, bun, gem, uv)
+        manager: String,
+        /// Manifest commit hash to roll back to
+        commit: String,
     },
 }
 
@@ -676,6 +694,11 @@ impl Cli {
                 IdentityAction::Reset => identity::reset().await,
             },
             Commands::History { file, limit } => history::run(file, *limit).await,
+            Commands::Rollback { action } => match action {
+                RollbackAction::Packages { manager, commit } => {
+                    rollback::packages(manager, commit).await
+                }
+            },
             Commands::Collab { action } => match action {
                 CollabAction::Init { project } => collab::init(project.as_deref()).await,
                 CollabAction::Join { url } => collab::join(url).await,

--- a/src/cli/commands/rollback.rs
+++ b/src/cli/commands/rollback.rs
@@ -1,30 +1,12 @@
 use crate::cli::Output;
-use crate::packages::{BunManager, GemManager, NpmManager, PackageManager, PnpmManager, UvManager};
 use crate::sync::{GitBackend, SyncEngine};
 use anyhow::Result;
 use std::collections::HashSet;
 
-/// Roll back a package manager's installed set to the manifest as of `commit`.
-///
-/// Reverse-delta: install packages the snapshot had but this machine lacks, and
-/// uninstall packages installed since. A follow-up sync records the removals
-/// (via `detect_removed_packages`) and rewrites the union manifest.
+/// Reverse-delta against the union manifest at `commit`; the follow-up sync records removals.
 pub async fn packages(manager: &str, commit: &str) -> Result<()> {
-    if commit.is_empty() || !commit.chars().all(|c| c.is_ascii_hexdigit()) {
-        anyhow::bail!("Invalid commit hash: {}", commit);
-    }
-
-    let pkg_manager: Box<dyn PackageManager> = match manager {
-        "npm" => Box::new(NpmManager::new()),
-        "pnpm" => Box::new(PnpmManager::new()),
-        "bun" => Box::new(BunManager::new()),
-        "gem" => Box::new(GemManager::new()),
-        "uv" => Box::new(UvManager::new()),
-        "brew_formulae" | "brew_casks" | "brew_taps" => {
-            anyhow::bail!("Rollback for brew is not yet supported");
-        }
-        other => anyhow::bail!("Unknown package manager: {}", other),
-    };
+    let pkg_manager = crate::packages::manager_for_key(manager)
+        .ok_or_else(|| anyhow::anyhow!("Rollback is not supported for {}", manager))?;
 
     if !pkg_manager.is_available().await {
         anyhow::bail!("{} is not available on this machine", manager);

--- a/src/cli/commands/rollback.rs
+++ b/src/cli/commands/rollback.rs
@@ -52,9 +52,11 @@ pub async fn packages(manager: &str, commit: &str) -> Result<()> {
         Output::list_item(&format!("install {}", pkg));
     }
 
+    let mut failed = 0;
     for pkg in &to_uninstall {
         if let Err(e) = pkg_manager.uninstall(pkg).await {
             Output::warning(&format!("Failed to uninstall {}: {}", pkg, e));
+            failed += 1;
         }
     }
     if !to_install.is_empty() {
@@ -70,5 +72,10 @@ pub async fn packages(manager: &str, commit: &str) -> Result<()> {
     }
 
     Output::success("Rollback applied; syncing...");
-    super::sync::run(false, false, false).await
+    super::sync::run(false, false, false).await?;
+
+    if failed > 0 {
+        anyhow::bail!("{} package(s) failed to uninstall", failed);
+    }
+    Ok(())
 }

--- a/src/cli/commands/rollback.rs
+++ b/src/cli/commands/rollback.rs
@@ -1,5 +1,6 @@
 use crate::cli::Output;
-use crate::sync::{GitBackend, SyncEngine};
+use crate::config::Config;
+use crate::sync::{GitBackend, SyncEngine, SyncState};
 use anyhow::Result;
 use std::collections::HashSet;
 
@@ -8,6 +9,11 @@ pub async fn packages(manager: &str, commit: &str) -> Result<()> {
     let pkg_manager = crate::packages::manager_for_key(manager)
         .ok_or_else(|| anyhow::anyhow!("Rollback is not supported for {}", manager))?;
 
+    let config = Config::load()?;
+    let state = SyncState::load()?;
+    if !config.is_manager_enabled(&state.machine_id, manager) {
+        anyhow::bail!("{} is disabled for this machine", manager);
+    }
     if !pkg_manager.is_available().await {
         anyhow::bail!("{} is not available on this machine", manager);
     }
@@ -15,6 +21,10 @@ pub async fn packages(manager: &str, commit: &str) -> Result<()> {
     let manifest = crate::sync::packages::manifest_filename(manager)
         .ok_or_else(|| anyhow::anyhow!("No manifest for {}", manager))?;
     let repo_path = format!("manifests/{}", manifest);
+
+    // Removal tombstones are diffed against the saved package list, so it must
+    // match what is installed before anything is removed.
+    super::sync::run(false, false, false).await?;
 
     let sync_path = SyncEngine::sync_path()?;
     let git = GitBackend::open(&sync_path)?;
@@ -52,11 +62,11 @@ pub async fn packages(manager: &str, commit: &str) -> Result<()> {
         Output::list_item(&format!("install {}", pkg));
     }
 
-    let mut failed = 0;
+    let mut failed: Vec<&str> = Vec::new();
     for pkg in &to_uninstall {
         if let Err(e) = pkg_manager.uninstall(pkg).await {
             Output::warning(&format!("Failed to uninstall {}: {}", pkg, e));
-            failed += 1;
+            failed.push(pkg);
         }
     }
     if !to_install.is_empty() {
@@ -69,13 +79,26 @@ pub async fn packages(manager: &str, commit: &str) -> Result<()> {
         if let Err(e) = pkg_manager.import_manifest(&manifest_text).await {
             Output::warning(&format!("Some packages failed to install: {}", e));
         }
+        // import_manifest swallows per-package errors, so check the result.
+        let now_installed: HashSet<String> = pkg_manager
+            .list_installed()
+            .await?
+            .into_iter()
+            .map(|p| p.name)
+            .collect();
+        for pkg in &to_install {
+            if !now_installed.contains(*pkg) {
+                Output::warning(&format!("Failed to install {}", pkg));
+                failed.push(pkg);
+            }
+        }
     }
 
     Output::success("Rollback applied; syncing...");
     super::sync::run(false, false, false).await?;
 
-    if failed > 0 {
-        anyhow::bail!("{} package(s) failed to uninstall", failed);
+    if !failed.is_empty() {
+        anyhow::bail!("{} package(s) failed: {}", failed.len(), failed.join(", "));
     }
     Ok(())
 }

--- a/src/cli/commands/rollback.rs
+++ b/src/cli/commands/rollback.rs
@@ -1,0 +1,92 @@
+use crate::cli::Output;
+use crate::packages::{BunManager, GemManager, NpmManager, PackageManager, PnpmManager, UvManager};
+use crate::sync::{GitBackend, SyncEngine};
+use anyhow::Result;
+use std::collections::HashSet;
+
+/// Roll back a package manager's installed set to the manifest as of `commit`.
+///
+/// Reverse-delta: install packages the snapshot had but this machine lacks, and
+/// uninstall packages installed since. A follow-up sync records the removals
+/// (via `detect_removed_packages`) and rewrites the union manifest.
+pub async fn packages(manager: &str, commit: &str) -> Result<()> {
+    if commit.is_empty() || !commit.chars().all(|c| c.is_ascii_hexdigit()) {
+        anyhow::bail!("Invalid commit hash: {}", commit);
+    }
+
+    let pkg_manager: Box<dyn PackageManager> = match manager {
+        "npm" => Box::new(NpmManager::new()),
+        "pnpm" => Box::new(PnpmManager::new()),
+        "bun" => Box::new(BunManager::new()),
+        "gem" => Box::new(GemManager::new()),
+        "uv" => Box::new(UvManager::new()),
+        "brew_formulae" | "brew_casks" | "brew_taps" => {
+            anyhow::bail!("Rollback for brew is not yet supported");
+        }
+        other => anyhow::bail!("Unknown package manager: {}", other),
+    };
+
+    if !pkg_manager.is_available().await {
+        anyhow::bail!("{} is not available on this machine", manager);
+    }
+
+    let manifest = crate::sync::packages::manifest_filename(manager)
+        .ok_or_else(|| anyhow::anyhow!("No manifest for {}", manager))?;
+    let repo_path = format!("manifests/{}", manifest);
+
+    let sync_path = SyncEngine::sync_path()?;
+    let git = GitBackend::open(&sync_path)?;
+    let snapshot = git.show_at_commit(commit, &repo_path)?;
+    let snapshot = String::from_utf8_lossy(&snapshot);
+    let target: HashSet<String> = snapshot
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect();
+
+    let installed: HashSet<String> = pkg_manager
+        .list_installed()
+        .await?
+        .into_iter()
+        .map(|p| p.name)
+        .collect();
+
+    let mut to_install: Vec<&String> = target.difference(&installed).collect();
+    let mut to_uninstall: Vec<&String> = installed.difference(&target).collect();
+    to_install.sort();
+    to_uninstall.sort();
+
+    if to_install.is_empty() && to_uninstall.is_empty() {
+        Output::info(&format!("{} already matches that snapshot", manager));
+        return Ok(());
+    }
+
+    Output::header(&format!("Rolling back {}", manager));
+    for pkg in &to_uninstall {
+        Output::list_item(&format!("uninstall {}", pkg));
+    }
+    for pkg in &to_install {
+        Output::list_item(&format!("install {}", pkg));
+    }
+
+    for pkg in &to_uninstall {
+        if let Err(e) = pkg_manager.uninstall(pkg).await {
+            Output::warning(&format!("Failed to uninstall {}: {}", pkg, e));
+        }
+    }
+    if !to_install.is_empty() {
+        let manifest_text = to_install
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        if let Err(e) = pkg_manager.import_manifest(&manifest_text).await {
+            Output::warning(&format!("Some packages failed to install: {}", e));
+        }
+    }
+
+    Output::success("Rollback applied; syncing...");
+    super::sync::run(false, false, false).await
+}

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -206,6 +206,7 @@ impl App {
         let exe = std::env::current_exe().unwrap_or_else(|_| "tether".into());
         match std::process::Command::new(exe)
             .args(args)
+            .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()
@@ -1104,6 +1105,10 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
                         app.packages.history_diff = load_pkg_diff(&manager, &commit_hash);
                         app.packages.history_commit = Some(commit_hash);
                     }
+                    let new_rows = widgets::packages::build_rows(&app.state, &app.packages);
+                    if app.packages.cursor >= new_rows.len() {
+                        app.packages.cursor = new_rows.len().saturating_sub(1);
+                    }
                 }
                 widgets::packages::PkgRow::DiffRow { .. } => {}
             }
@@ -1209,7 +1214,10 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
                         }
                     }
                 }
-            } else if app.active_tab == Tab::Packages {
+            } else if app.active_tab == Tab::Packages
+                && app.uninstalling.is_none()
+                && app.installing.is_none()
+            {
                 let rows = widgets::packages::build_rows(&app.state, &app.packages);
                 if let Some(widgets::packages::PkgRow::HistoryEntry {
                     commit_hash,
@@ -1229,6 +1237,14 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
                             build_rollback_confirm(&app.state, &manager, &commit_hash, &short_hash)
                         {
                             app.packages.rollback_confirm = Some(confirm);
+                        } else {
+                            app.flash_error = Some((
+                                Instant::now(),
+                                format!(
+                                    "Could not read the {} manifest at {}",
+                                    manager, short_hash
+                                ),
+                            ));
                         }
                     }
                 }
@@ -1945,7 +1961,13 @@ fn draw(f: &mut Frame, app: &App) {
         f,
         main_chunks[0],
         &app.state,
-        app.sync_child.is_some(),
+        app.sync_child.as_ref().map(|(label, _)| {
+            if label.starts_with("rollback") {
+                "rolling back"
+            } else {
+                "syncing"
+            }
+        }),
         app.daemon_op,
         flash,
         app.uninstalling.as_ref(),

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -457,7 +457,18 @@ pub fn run() -> Result<()> {
         }
 
         if app.should_quit {
-            break;
+            // A killed rollback leaves packages half-removed with no tombstones.
+            let rollback_running =
+                matches!(&app.sync_child, Some((label, _)) if label.starts_with("rollback"));
+            if rollback_running {
+                app.should_quit = false;
+                app.flash_error = Some((
+                    Instant::now(),
+                    "Rollback in progress, wait for it to finish".to_string(),
+                ));
+            } else {
+                break;
+            }
         }
     }
 

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -557,16 +557,19 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
         match key.code {
             KeyCode::Char('y') | KeyCode::Enter => {
                 if let Some(rb) = app.packages.rollback_confirm.take() {
-                    if app.spawn_tether(&["rollback", "packages", &rb.manager, &rb.commit]) {
+                    if app.sync_child.is_some() {
+                        app.flash_error = Some((
+                            Instant::now(),
+                            "Another tether command is still running".to_string(),
+                        ));
+                    } else if app.spawn_tether(&["rollback", "packages", &rb.manager, &rb.commit]) {
                         app.flash_message = Some((
                             Instant::now(),
                             format!("Rolling back {} to {}", rb.manager, rb.short_hash),
                         ));
                     } else {
-                        app.flash_error = Some((
-                            Instant::now(),
-                            "Another tether command is still running".to_string(),
-                        ));
+                        app.flash_error =
+                            Some((Instant::now(), "Could not start tether".to_string()));
                     }
                 }
             }
@@ -703,7 +706,11 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
             KeyCode::Char('k') | KeyCode::Up => {
                 picker.cursor = picker.cursor.saturating_sub(1);
             }
-            KeyCode::Enter if !picker.items.is_empty() && picker.cursor < picker.items.len() => {
+            KeyCode::Enter
+                if !picker.items.is_empty()
+                    && picker.cursor < picker.items.len()
+                    && app.sync_child.is_none() =>
+            {
                 let item = &picker.items[picker.cursor];
                 app.pkg_install_confirm = Some((item.manager_key.clone(), item.name.clone()));
             }
@@ -1102,7 +1109,10 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
                 widgets::packages::PkgRow::Package {
                     manager_key, name, ..
                 } => {
-                    if app.uninstalling.is_none() && manager_key != "brew_taps" {
+                    if app.uninstalling.is_none()
+                        && app.sync_child.is_none()
+                        && manager_key != "brew_taps"
+                    {
                         app.uninstall_confirm = Some((manager_key.clone(), name.clone()));
                     }
                 }
@@ -1451,12 +1461,16 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
                         app.packages.history.clear();
                     } else {
                         app.packages.history = load_pkg_history(&manager_key);
-                        app.packages.history_manager = Some(manager_key);
+                        app.packages.history_manager = Some(manager_key.clone());
                     }
+                    // Rows above the cursor may have vanished, so re-find the header.
                     let new_rows = widgets::packages::build_rows(&app.state, &app.packages);
-                    if app.packages.cursor >= new_rows.len() {
-                        app.packages.cursor = new_rows.len().saturating_sub(1);
-                    }
+                    app.packages.cursor = new_rows
+                        .iter()
+                        .position(|r| {
+                            matches!(r, widgets::packages::PkgRow::Header { manager_key: k, .. } if *k == manager_key)
+                        })
+                        .unwrap_or(0);
                 }
             }
         }
@@ -1558,8 +1572,9 @@ fn refresh_files_expanded(app: &mut App) {
 fn refresh_packages_expanded(app: &mut App) {
     if let Some(ref manager) = app.packages.history_manager {
         app.packages.history = load_pkg_history(manager);
-        app.packages.history_commit = None;
-        app.packages.history_diff.clear();
+        if let Some(ref commit) = app.packages.history_commit {
+            app.packages.history_diff = load_pkg_diff(manager, commit);
+        }
     }
     let rows = widgets::packages::build_rows(&app.state, &app.packages).len();
     if app.packages.cursor >= rows {

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -112,6 +112,14 @@ impl FilesTabState {
     }
 }
 
+pub struct RollbackConfirm {
+    pub manager: String,
+    pub commit: String,
+    pub short_hash: String,
+    pub install: usize,
+    pub uninstall: usize,
+}
+
 pub struct PackagesTabState {
     pub cursor: usize,
     /// Manager whose installed-package list is expanded.
@@ -122,6 +130,7 @@ pub struct PackagesTabState {
     /// History entry whose diff is expanded.
     pub history_commit: Option<String>,
     pub history_diff: Vec<String>,
+    pub rollback_confirm: Option<RollbackConfirm>,
 }
 
 impl PackagesTabState {
@@ -133,6 +142,7 @@ impl PackagesTabState {
             history: Vec::new(),
             history_commit: None,
             history_diff: Vec::new(),
+            rollback_confirm: None,
         }
     }
 }
@@ -195,6 +205,21 @@ impl App {
         let exe = std::env::current_exe().unwrap_or_else(|_| "tether".into());
         if let Ok(child) = std::process::Command::new(exe)
             .arg("sync")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        {
+            self.sync_child = Some(child);
+        }
+    }
+
+    fn spawn_rollback(&mut self, manager: &str, commit: &str) {
+        if self.sync_child.is_some() {
+            return;
+        }
+        let exe = std::env::current_exe().unwrap_or_else(|_| "tether".into());
+        if let Ok(child) = std::process::Command::new(exe)
+            .args(["rollback", "packages", manager, commit])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()
@@ -511,6 +536,26 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
             }
             KeyCode::Char('n') | KeyCode::Esc => {
                 app.files.restore_confirm = None;
+            }
+            _ => {}
+        }
+        return;
+    }
+
+    // Package rollback confirmation popup
+    if app.packages.rollback_confirm.is_some() {
+        match key.code {
+            KeyCode::Char('y') | KeyCode::Enter => {
+                if let Some(rb) = app.packages.rollback_confirm.take() {
+                    app.spawn_rollback(&rb.manager, &rb.commit);
+                    app.flash_message = Some((
+                        Instant::now(),
+                        format!("Rolling back {} to {}", rb.manager, rb.short_hash),
+                    ));
+                }
+            }
+            KeyCode::Char('n') | KeyCode::Esc => {
+                app.packages.rollback_confirm = None;
             }
             _ => {}
         }
@@ -1160,6 +1205,29 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
                         }
                     }
                 }
+            } else if app.active_tab == Tab::Packages {
+                let rows = widgets::packages::build_rows(&app.state, &app.packages);
+                if let Some(widgets::packages::PkgRow::HistoryEntry {
+                    commit_hash,
+                    short_hash,
+                    ..
+                }) = rows.get(app.packages.cursor)
+                {
+                    let commit_hash = commit_hash.clone();
+                    let short_hash = short_hash.clone();
+                    if let Some(manager) = app.packages.history_manager.clone() {
+                        if manager.starts_with("brew_") {
+                            app.flash_error = Some((
+                                Instant::now(),
+                                "Rollback for brew is not yet supported".to_string(),
+                            ));
+                        } else if let Some(confirm) =
+                            build_rollback_confirm(&app.state, &manager, &commit_hash, &short_hash)
+                        {
+                            app.packages.rollback_confirm = Some(confirm);
+                        }
+                    }
+                }
             }
         }
         KeyCode::Char('x') => {
@@ -1379,6 +1447,47 @@ fn load_pkg_history(manager_key: &str) -> Vec<crate::sync::FileLogEntry> {
         .and_then(|p| crate::sync::GitBackend::open(&p).ok())
         .and_then(|git| git.file_log_changed(&repo_path, 10, false).ok())
         .unwrap_or_default()
+}
+
+/// Compute the install/uninstall counts for rolling a manager back to a commit.
+fn build_rollback_confirm(
+    state: &DashboardState,
+    manager: &str,
+    commit: &str,
+    short_hash: &str,
+) -> Option<RollbackConfirm> {
+    let manifest = crate::sync::packages::manifest_filename(manager)?;
+    let repo_path = format!("manifests/{}", manifest);
+    let sync_path = crate::sync::SyncEngine::sync_path().ok()?;
+    let git = crate::sync::GitBackend::open(&sync_path).ok()?;
+    let snapshot = git.show_at_commit(commit, &repo_path).ok()?;
+    let snapshot = String::from_utf8_lossy(&snapshot);
+    let target: HashSet<&str> = snapshot
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    let current_machine_id = state
+        .sync_state
+        .as_ref()
+        .map(|s| s.machine_id.as_str())
+        .unwrap_or("");
+    let installed: HashSet<&str> = state
+        .machines
+        .iter()
+        .find(|m| m.machine_id == current_machine_id)
+        .and_then(|m| m.packages.get(manager))
+        .map(|v| v.iter().map(String::as_str).collect())
+        .unwrap_or_default();
+
+    Some(RollbackConfirm {
+        manager: manager.to_string(),
+        commit: commit.to_string(),
+        short_hash: short_hash.to_string(),
+        install: target.difference(&installed).count(),
+        uninstall: installed.difference(&target).count(),
+    })
 }
 
 /// Load the manifest diff for a manager at a commit.
@@ -1923,6 +2032,20 @@ fn draw(f: &mut Frame, app: &App) {
             f,
             "Restore",
             &format!("Restore {} to {}?", dotfile_path, short_hash),
+            Color::Yellow,
+        );
+    }
+
+    // Package rollback confirmation popup
+    if let Some(ref rb) = app.packages.rollback_confirm {
+        let label = widgets::manager_label(&rb.manager);
+        render_confirm_popup(
+            f,
+            "Roll back packages",
+            &format!(
+                "Roll back {} to {} (+{} install, -{} uninstall)?",
+                label, rb.short_hash, rb.install, rb.uninstall
+            ),
             Color::Yellow,
         );
     }

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -112,6 +112,31 @@ impl FilesTabState {
     }
 }
 
+pub struct PackagesTabState {
+    pub cursor: usize,
+    /// Manager whose installed-package list is expanded.
+    pub expanded: Option<String>,
+    /// Manager whose manifest history is open.
+    pub history_manager: Option<String>,
+    pub history: Vec<crate::sync::FileLogEntry>,
+    /// History entry whose diff is expanded.
+    pub history_commit: Option<String>,
+    pub history_diff: Vec<String>,
+}
+
+impl PackagesTabState {
+    fn new() -> Self {
+        Self {
+            cursor: 0,
+            expanded: None,
+            history_manager: None,
+            history: Vec::new(),
+            history_commit: None,
+            history_diff: Vec::new(),
+        }
+    }
+}
+
 pub struct App {
     state: DashboardState,
     active_tab: Tab,
@@ -127,8 +152,7 @@ pub struct App {
     flash_error: Option<(Instant, String)>,
     flash_message: Option<(Instant, String)>,
     list_edit: Option<ListEditState>,
-    pkg_expanded: Option<String>,
-    pkg_cursor: usize,
+    packages: PackagesTabState,
     uninstall_confirm: Option<(String, String)>,
     uninstalling: Option<(String, String)>,
     uninstall_rx: Option<std::sync::mpsc::Receiver<std::result::Result<(), String>>>,
@@ -189,9 +213,7 @@ impl App {
     fn item_count(&self) -> usize {
         match self.active_tab {
             Tab::Files => widgets::files::build_rows(&self.state, &self.files).len(),
-            Tab::Packages => {
-                widgets::packages::build_rows(&self.state, self.pkg_expanded.as_deref()).len()
-            }
+            Tab::Packages => widgets::packages::build_rows(&self.state, &self.packages).len(),
             Tab::Machines => {
                 widgets::machines::build_rows(&self.state, self.machine_expanded.as_deref()).len()
             }
@@ -234,8 +256,7 @@ pub fn run() -> Result<()> {
         flash_error: None,
         flash_message: None,
         list_edit: None,
-        pkg_expanded: None,
-        pkg_cursor: 0,
+        packages: PackagesTabState::new(),
         uninstall_confirm: None,
         uninstalling: None,
         uninstall_rx: None,
@@ -1000,22 +1021,21 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
         return;
     }
 
-    // Packages tab Enter: expand/collapse or uninstall
+    // Packages tab Enter: expand package list, uninstall, or toggle a history diff
     if app.active_tab == Tab::Packages && key.code == KeyCode::Enter {
-        let rows = widgets::packages::build_rows(&app.state, app.pkg_expanded.as_deref());
-        if app.pkg_cursor < rows.len() {
-            match &rows[app.pkg_cursor] {
+        let rows = widgets::packages::build_rows(&app.state, &app.packages);
+        if app.packages.cursor < rows.len() {
+            match &rows[app.packages.cursor] {
                 widgets::packages::PkgRow::Header { manager_key, .. } => {
-                    if app.pkg_expanded.as_deref() == Some(manager_key.as_str()) {
-                        app.pkg_expanded = None;
+                    if app.packages.expanded.as_deref() == Some(manager_key.as_str()) {
+                        app.packages.expanded = None;
                     } else {
-                        app.pkg_expanded = Some(manager_key.clone());
+                        app.packages.expanded = Some(manager_key.clone());
                     }
                     // Clamp cursor to new row count
-                    let new_rows =
-                        widgets::packages::build_rows(&app.state, app.pkg_expanded.as_deref());
-                    if app.pkg_cursor >= new_rows.len() {
-                        app.pkg_cursor = new_rows.len().saturating_sub(1);
+                    let new_rows = widgets::packages::build_rows(&app.state, &app.packages);
+                    if app.packages.cursor >= new_rows.len() {
+                        app.packages.cursor = new_rows.len().saturating_sub(1);
                     }
                 }
                 widgets::packages::PkgRow::Package {
@@ -1025,6 +1045,18 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
                         app.uninstall_confirm = Some((manager_key.clone(), name.clone()));
                     }
                 }
+                widgets::packages::PkgRow::HistoryEntry { commit_hash, .. } => {
+                    let commit_hash = commit_hash.clone();
+                    if app.packages.history_commit.as_deref() == Some(commit_hash.as_str()) {
+                        app.packages.history_commit = None;
+                        app.packages.history_diff.clear();
+                    } else {
+                        let manager = app.packages.history_manager.clone().unwrap_or_default();
+                        app.packages.history_diff = load_pkg_diff(&manager, &commit_hash);
+                        app.packages.history_commit = Some(commit_hash);
+                    }
+                }
+                widgets::packages::PkgRow::DiffRow { .. } => {}
             }
         }
         return;
@@ -1277,8 +1309,8 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
                 }
             } else if app.active_tab == Tab::Packages {
                 let max = app.item_count().saturating_sub(1);
-                if app.pkg_cursor < max {
-                    app.pkg_cursor += 1;
+                if app.packages.cursor < max {
+                    app.packages.cursor += 1;
                 }
             } else if app.active_tab == Tab::Machines {
                 let max = app.item_count().saturating_sub(1);
@@ -1296,7 +1328,7 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
             if app.active_tab == Tab::Files {
                 app.files.cursor = app.files.cursor.saturating_sub(1);
             } else if app.active_tab == Tab::Packages {
-                app.pkg_cursor = app.pkg_cursor.saturating_sub(1);
+                app.packages.cursor = app.packages.cursor.saturating_sub(1);
             } else if app.active_tab == Tab::Machines {
                 app.machine_cursor = app.machine_cursor.saturating_sub(1);
             } else {
@@ -1304,11 +1336,63 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
                 *offset = offset.saturating_sub(1);
             }
         }
+        KeyCode::Char('h') => {
+            if app.active_tab == Tab::Packages {
+                let rows = widgets::packages::build_rows(&app.state, &app.packages);
+                if let Some(widgets::packages::PkgRow::Header { manager_key, .. }) =
+                    rows.get(app.packages.cursor)
+                {
+                    let manager_key = manager_key.clone();
+                    let was_open =
+                        app.packages.history_manager.as_deref() == Some(manager_key.as_str());
+                    app.packages.history_commit = None;
+                    app.packages.history_diff.clear();
+                    if was_open {
+                        app.packages.history_manager = None;
+                        app.packages.history.clear();
+                    } else {
+                        app.packages.history = load_pkg_history(&manager_key);
+                        app.packages.history_manager = Some(manager_key);
+                    }
+                    let new_rows = widgets::packages::build_rows(&app.state, &app.packages);
+                    if app.packages.cursor >= new_rows.len() {
+                        app.packages.cursor = new_rows.len().saturating_sub(1);
+                    }
+                }
+            }
+        }
         KeyCode::Char('?') => {
             app.show_help = !app.show_help;
         }
         _ => {}
     }
+}
+
+/// Load manifest commit history for a package manager.
+fn load_pkg_history(manager_key: &str) -> Vec<crate::sync::FileLogEntry> {
+    let Some(manifest) = crate::sync::packages::manifest_filename(manager_key) else {
+        return Vec::new();
+    };
+    let repo_path = format!("manifests/{}", manifest);
+    crate::sync::SyncEngine::sync_path()
+        .ok()
+        .and_then(|p| crate::sync::GitBackend::open(&p).ok())
+        .and_then(|git| git.file_log_changed(&repo_path, 10, false).ok())
+        .unwrap_or_default()
+}
+
+/// Load the manifest diff for a manager at a commit.
+fn load_pkg_diff(manager_key: &str, commit: &str) -> Vec<String> {
+    let Some(manifest) = crate::sync::packages::manifest_filename(manager_key) else {
+        return Vec::new();
+    };
+    let repo_path = format!("manifests/{}", manifest);
+    crate::sync::SyncEngine::sync_path()
+        .ok()
+        .and_then(|p| crate::sync::GitBackend::open(&p).ok())
+        .and_then(|git| git.file_diff(commit, &repo_path, &repo_path, false).ok())
+        .map(|d| d.lines().map(str::to_string).collect())
+        .unwrap_or_default()
 }
 
 /// Refresh expanded file history/diff after state reload
@@ -1791,13 +1875,7 @@ fn draw(f: &mut Frame, app: &App) {
         Tab::Overview => draw_overview(f, content_chunks[1], app),
         Tab::Files => widgets::files::render(f, content_chunks[1], &app.state, &app.files),
         Tab::Packages => {
-            widgets::packages::render(
-                f,
-                content_chunks[1],
-                &app.state,
-                app.pkg_expanded.as_deref(),
-                app.pkg_cursor,
-            );
+            widgets::packages::render(f, content_chunks[1], &app.state, &app.packages);
         }
         Tab::Machines => widgets::machines::render(
             f,

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -152,7 +152,7 @@ pub struct App {
     active_tab: Tab,
     scroll_offsets: [usize; 5],
     should_quit: bool,
-    sync_child: Option<std::process::Child>,
+    sync_child: Option<(String, std::process::Child)>,
     daemon_child: Option<std::process::Child>,
     daemon_op: DaemonOp,
     show_help: bool,
@@ -198,40 +198,35 @@ impl App {
         &mut self.scroll_offsets[idx]
     }
 
-    fn spawn_sync(&mut self) {
+    /// Run `tether <args>` in the background; false when a child is already running.
+    fn spawn_tether(&mut self, args: &[&str]) -> bool {
         if self.sync_child.is_some() {
-            return;
+            return false;
         }
         let exe = std::env::current_exe().unwrap_or_else(|_| "tether".into());
-        if let Ok(child) = std::process::Command::new(exe)
-            .arg("sync")
+        match std::process::Command::new(exe)
+            .args(args)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()
         {
-            self.sync_child = Some(child);
+            Ok(child) => {
+                self.sync_child = Some((args.join(" "), child));
+                true
+            }
+            Err(_) => false,
         }
     }
 
-    fn spawn_rollback(&mut self, manager: &str, commit: &str) {
-        if self.sync_child.is_some() {
-            return;
-        }
-        let exe = std::env::current_exe().unwrap_or_else(|_| "tether".into());
-        if let Ok(child) = std::process::Command::new(exe)
-            .args(["rollback", "packages", manager, commit])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-        {
-            self.sync_child = Some(child);
-        }
+    fn spawn_sync(&mut self) {
+        self.spawn_tether(&["sync"]);
     }
 
     fn reload_state(&mut self) {
         self.state = DashboardState::load();
         self.files.deleted = load_deleted_files(&self.state);
         refresh_files_expanded(self);
+        refresh_packages_expanded(self);
         self.last_refresh = Instant::now();
     }
 
@@ -345,8 +340,11 @@ pub fn run() -> Result<()> {
             }
         }
 
-        if let Some(ref mut child) = app.sync_child {
-            if let Ok(Some(_)) = child.try_wait() {
+        if let Some((ref label, ref mut child)) = app.sync_child {
+            if let Ok(Some(status)) = child.try_wait() {
+                if !status.success() {
+                    app.flash_error = Some((Instant::now(), format!("tether {} failed", label)));
+                }
                 app.sync_child = None;
                 app.reload_state();
             }
@@ -462,7 +460,7 @@ pub fn run() -> Result<()> {
         }
     }
 
-    if let Some(ref mut child) = app.sync_child {
+    if let Some((_, ref mut child)) = app.sync_child {
         let _ = child.kill();
         let _ = child.wait();
     }
@@ -547,11 +545,17 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
         match key.code {
             KeyCode::Char('y') | KeyCode::Enter => {
                 if let Some(rb) = app.packages.rollback_confirm.take() {
-                    app.spawn_rollback(&rb.manager, &rb.commit);
-                    app.flash_message = Some((
-                        Instant::now(),
-                        format!("Rolling back {} to {}", rb.manager, rb.short_hash),
-                    ));
+                    if app.spawn_tether(&["rollback", "packages", &rb.manager, &rb.commit]) {
+                        app.flash_message = Some((
+                            Instant::now(),
+                            format!("Rolling back {} to {}", rb.manager, rb.short_hash),
+                        ));
+                    } else {
+                        app.flash_error = Some((
+                            Instant::now(),
+                            "Another tether command is still running".to_string(),
+                        ));
+                    }
                 }
             }
             KeyCode::Char('n') | KeyCode::Esc => {
@@ -1216,10 +1220,10 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
                     let commit_hash = commit_hash.clone();
                     let short_hash = short_hash.clone();
                     if let Some(manager) = app.packages.history_manager.clone() {
-                        if manager.starts_with("brew_") {
+                        if crate::packages::manager_for_key(&manager).is_none() {
                             app.flash_error = Some((
                                 Instant::now(),
-                                "Rollback for brew is not yet supported".to_string(),
+                                format!("Rollback is not supported for {}", manager),
                             ));
                         } else if let Some(confirm) =
                             build_rollback_confirm(&app.state, &manager, &commit_hash, &short_hash)
@@ -1523,6 +1527,19 @@ fn refresh_files_expanded(app: &mut App) {
     }
 }
 
+/// Reload open manifest history and clamp the cursor after state reload
+fn refresh_packages_expanded(app: &mut App) {
+    if let Some(ref manager) = app.packages.history_manager {
+        app.packages.history = load_pkg_history(manager);
+        app.packages.history_commit = None;
+        app.packages.history_diff.clear();
+    }
+    let rows = widgets::packages::build_rows(&app.state, &app.packages).len();
+    if app.packages.cursor >= rows {
+        app.packages.cursor = rows.saturating_sub(1);
+    }
+}
+
 /// Refresh list_edit items from current config state
 fn refresh_list_edit(app: &mut App) {
     let Some(ref le) = app.list_edit else {
@@ -1563,12 +1580,8 @@ async fn run_uninstall(manager_key: &str, package: &str) -> std::result::Result<
 
     let manager: Box<dyn PackageManager> = match manager_key {
         "brew_formulae" | "brew_casks" => Box::new(BrewManager),
-        "npm" => Box::new(NpmManager),
-        "pnpm" => Box::new(PnpmManager),
-        "bun" => Box::new(BunManager),
-        "gem" => Box::new(GemManager),
-        "uv" => Box::new(UvManager),
-        _ => return Err(format!("Unknown manager: {}", manager_key)),
+        _ => manager_for_key(manager_key)
+            .ok_or_else(|| format!("Unknown manager: {}", manager_key))?,
     };
 
     manager.uninstall(package).await.map_err(|e| e.to_string())
@@ -1587,12 +1600,8 @@ async fn run_install(manager_key: &str, package: &str) -> std::result::Result<()
 
     let manager: Box<dyn PackageManager> = match manager_key {
         "brew_formulae" => Box::new(BrewManager),
-        "npm" => Box::new(NpmManager),
-        "pnpm" => Box::new(PnpmManager),
-        "bun" => Box::new(BunManager),
-        "gem" => Box::new(GemManager),
-        "uv" => Box::new(UvManager),
-        _ => return Err(format!("Unknown manager: {}", manager_key)),
+        _ => manager_for_key(manager_key)
+            .ok_or_else(|| format!("Unknown manager: {}", manager_key))?,
     };
 
     manager

--- a/src/dashboard/widgets/help.rs
+++ b/src/dashboard/widgets/help.rs
@@ -151,7 +151,15 @@ pub fn render_overlay(f: &mut Frame) {
         )),
         Line::from(vec![
             Span::styled("  Enter     ", Style::default().fg(Color::Yellow).bold()),
-            Span::raw("Expand/uninstall"),
+            Span::raw("Expand/uninstall, toggle history diff"),
+        ]),
+        Line::from(vec![
+            Span::styled("  h         ", Style::default().fg(Color::Yellow).bold()),
+            Span::raw("Toggle manifest history"),
+        ]),
+        Line::from(vec![
+            Span::styled("  R         ", Style::default().fg(Color::Yellow).bold()),
+            Span::raw("Roll back to history entry"),
         ]),
         Line::from(""),
         Line::from(vec![

--- a/src/dashboard/widgets/packages.rs
+++ b/src/dashboard/widgets/packages.rs
@@ -1,5 +1,7 @@
 use super::manager_label;
+use crate::cli::output::relative_time;
 use crate::dashboard::state::DashboardState;
+use crate::dashboard::PackagesTabState;
 use ratatui::{prelude::*, widgets::*};
 
 /// Row in the flat package list
@@ -13,10 +15,20 @@ pub enum PkgRow {
         manager_key: String,
         name: String,
     },
+    HistoryEntry {
+        commit_hash: String,
+        short_hash: String,
+        date: String,
+        machine_id: String,
+        message: String,
+    },
+    DiffRow {
+        line: String,
+    },
 }
 
 /// Build the flat list of rows from machine state
-pub fn build_rows(state: &DashboardState, expanded: Option<&str>) -> Vec<PkgRow> {
+pub fn build_rows(state: &DashboardState, pt: &PackagesTabState) -> Vec<PkgRow> {
     let current_machine_id = state
         .sync_state
         .as_ref()
@@ -42,7 +54,25 @@ pub fn build_rows(state: &DashboardState, expanded: Option<&str>) -> Vec<PkgRow>
             label: manager_label(key).to_string(),
             count: packages.len(),
         });
-        if expanded == Some(key.as_str()) {
+
+        if pt.history_manager.as_deref() == Some(key.as_str()) {
+            for entry in &pt.history {
+                rows.push(PkgRow::HistoryEntry {
+                    commit_hash: entry.commit_hash.clone(),
+                    short_hash: entry.short_hash.clone(),
+                    date: relative_time(entry.date),
+                    machine_id: entry.machine_id.clone(),
+                    message: entry.message.clone(),
+                });
+                if pt.history_commit.as_deref() == Some(entry.commit_hash.as_str()) {
+                    for line in &pt.history_diff {
+                        rows.push(PkgRow::DiffRow { line: line.clone() });
+                    }
+                }
+            }
+        }
+
+        if pt.expanded.as_deref() == Some(key.as_str()) {
             let mut sorted_pkgs: Vec<_> = (*packages).clone();
             sorted_pkgs.sort();
             for pkg in &sorted_pkgs {
@@ -56,14 +86,9 @@ pub fn build_rows(state: &DashboardState, expanded: Option<&str>) -> Vec<PkgRow>
     rows
 }
 
-pub fn render(
-    f: &mut Frame,
-    area: Rect,
-    state: &DashboardState,
-    expanded: Option<&str>,
-    cursor: usize,
-) {
-    let rows = build_rows(state, expanded);
+pub fn render(f: &mut Frame, area: Rect, state: &DashboardState, pt: &PackagesTabState) {
+    let rows = build_rows(state, pt);
+    let cursor = pt.cursor;
 
     let block = Block::default()
         .title(" Packages ")
@@ -101,7 +126,7 @@ pub fn render(
                 count,
                 ..
             } => {
-                let arrow = if expanded == Some(manager_key.as_str()) {
+                let arrow = if pt.expanded.as_deref() == Some(manager_key.as_str()) {
                     "v"
                 } else {
                     ">"
@@ -144,6 +169,78 @@ pub fn render(
                 let line = Line::from(vec![
                     Span::styled(format!("      {}", name), style),
                     Span::styled(" ".repeat(inner_area.width as usize), style),
+                ]);
+                f.render_widget(Paragraph::new(line), row_area);
+            }
+            PkgRow::HistoryEntry {
+                commit_hash,
+                short_hash,
+                date,
+                machine_id,
+                message,
+            } => {
+                let bg = if is_selected {
+                    Color::Indexed(240)
+                } else {
+                    Color::Reset
+                };
+                let arrow = if pt.history_commit.as_deref() == Some(commit_hash.as_str()) {
+                    "v"
+                } else {
+                    ">"
+                };
+                let line = Line::from(vec![
+                    Span::styled(
+                        format!("     {} ", arrow),
+                        Style::default().fg(Color::Gray).bg(bg),
+                    ),
+                    Span::styled(
+                        short_hash.clone(),
+                        Style::default().fg(Color::Yellow).bg(bg).bold(),
+                    ),
+                    Span::styled(
+                        format!("  {:>12}", date),
+                        Style::default().fg(Color::Gray).bg(bg),
+                    ),
+                    Span::styled(
+                        format!("  {:15}", machine_id),
+                        Style::default().fg(Color::Gray).bg(bg),
+                    ),
+                    Span::styled(
+                        format!("  {}", message),
+                        Style::default().fg(Color::White).bg(bg),
+                    ),
+                    Span::styled(
+                        " ".repeat(inner_area.width as usize),
+                        Style::default().bg(bg),
+                    ),
+                ]);
+                f.render_widget(Paragraph::new(line), row_area);
+            }
+            PkgRow::DiffRow { line: diff_line } => {
+                let bg = if is_selected {
+                    Color::Indexed(240)
+                } else {
+                    Color::Reset
+                };
+                let fg = if diff_line.starts_with("@@") {
+                    Color::Cyan
+                } else if diff_line.starts_with("+++") || diff_line.starts_with("---") {
+                    Color::Gray
+                } else if diff_line.starts_with('+') {
+                    Color::Green
+                } else if diff_line.starts_with('-') {
+                    Color::Red
+                } else {
+                    Color::Gray
+                };
+                let line = Line::from(vec![
+                    Span::styled("        ", Style::default().bg(bg)),
+                    Span::styled(diff_line.clone(), Style::default().fg(fg).bg(bg)),
+                    Span::styled(
+                        " ".repeat(inner_area.width as usize),
+                        Style::default().bg(bg),
+                    ),
                 ]);
                 f.render_widget(Paragraph::new(line), row_area);
             }

--- a/src/dashboard/widgets/status.rs
+++ b/src/dashboard/widgets/status.rs
@@ -13,7 +13,7 @@ pub fn render(
     f: &mut Frame,
     area: Rect,
     state: &DashboardState,
-    syncing: bool,
+    running: Option<&str>,
     daemon_op: DaemonOp,
     flash: Option<FlashMessage>,
     uninstalling: Option<&(String, String)>,
@@ -68,9 +68,9 @@ pub fn render(
     spans.push(Span::raw("  "));
 
     // Sync status
-    if syncing {
+    if let Some(label) = running {
         spans.push(Span::styled(
-            "syncing...",
+            format!("{}...", label),
             Style::default().fg(Color::Yellow),
         ));
     } else if let Some(ref sync_state) = state.sync_state {

--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -24,6 +24,18 @@ pub fn command_error_message(output: &std::process::Output) -> String {
         .join("\n")
 }
 
+/// Look up a simple (non-brew) manager by its machine-state key.
+pub fn manager_for_key(key: &str) -> Option<Box<dyn PackageManager>> {
+    Some(match key {
+        "npm" => Box::new(NpmManager::new()),
+        "pnpm" => Box::new(PnpmManager::new()),
+        "bun" => Box::new(BunManager::new()),
+        "gem" => Box::new(GemManager::new()),
+        "uv" => Box::new(UvManager::new()),
+        _ => return None,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::command_error_message;

--- a/src/sync/packages.rs
+++ b/src/sync/packages.rs
@@ -1,9 +1,6 @@
 use crate::cli::Output;
 use crate::config::Config;
-use crate::packages::{
-    normalize_formula_name, BrewManager, BrewfilePackages, BunManager, GemManager, NpmManager,
-    PackageManager, PnpmManager, UvManager,
-};
+use crate::packages::{normalize_formula_name, BrewManager, BrewfilePackages, PackageManager};
 use crate::sync::state::PackageState;
 use crate::sync::{MachineState, SyncState};
 use anyhow::Result;
@@ -302,14 +299,8 @@ async fn import_simple_manager(
         return false;
     }
 
-    // Get the appropriate manager
-    let manager: Box<dyn PackageManager> = match def.state_key {
-        "npm" => Box::new(NpmManager::new()),
-        "pnpm" => Box::new(PnpmManager::new()),
-        "bun" => Box::new(BunManager::new()),
-        "gem" => Box::new(GemManager::new()),
-        "uv" => Box::new(UvManager::new()),
-        _ => return false,
+    let Some(manager) = crate::packages::manager_for_key(def.state_key) else {
+        return false;
     };
 
     if !manager.is_available().await {

--- a/src/sync/packages.rs
+++ b/src/sync/packages.rs
@@ -20,6 +20,18 @@ struct PackageManagerDef {
     manifest_file: &'static str,
 }
 
+/// Map a machine-state package key to its manifest filename in `manifests/`.
+/// All three brew keys (`brew_formulae`, `brew_casks`, `brew_taps`) share the Brewfile.
+pub fn manifest_filename(state_key: &str) -> Option<&'static str> {
+    if state_key.starts_with("brew_") {
+        return Some("Brewfile");
+    }
+    SIMPLE_MANAGERS
+        .iter()
+        .find(|d| d.state_key == state_key)
+        .map(|d| d.manifest_file)
+}
+
 const SIMPLE_MANAGERS: &[PackageManagerDef] = &[
     PackageManagerDef {
         state_key: "npm",


### PR DESCRIPTION
## Summary

- Packages tab gains a manifest history view: `h` opens a manager's commit history, `Enter` on an entry shows the diff — mirroring the Files tab.
- New `tether rollback packages <manager> <commit>` command rolls a package manager's installed set back to a manifest snapshot: it computes the reverse delta (install what the snapshot had, uninstall what was added since), applies it, then re-syncs so removals are recorded and the union manifest updates.
- Dashboard: `R` on a history entry opens a confirmation modal with `+install / −uninstall` counts, then spawns the rollback command as a subprocess (same pattern as `sync`).

## Scope / limitations

- **Brew is not covered.** Its Brewfile format and cask/tap handling need a separate pass; `R` on a brew entry reports "not yet supported". History viewing still works for brew.
- **Fleet behaviour.** Rolling back affects this machine and records removals so they don't propagate back to it; it does not force-uninstall on other machines (the package model is descriptive, not declarative).
- Projects rollback is not included (would require a new Projects tab).

## Test plan

- [ ] Packages tab: `h` lists a manager's manifest history, `Enter` shows the diff
- [ ] `R` on a history entry shows the confirmation modal with correct install/uninstall counts
- [ ] Confirming runs `tether rollback packages` and the manager's installed set matches the snapshot afterward
- [ ] `tether rollback packages <manager> <commit>` works standalone from the CLI
- [ ] Brew history entries report rollback is unsupported rather than erroring