### PR TITLE
fix: satisfy clippy on Rust 1.98

### DIFF
--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -580,12 +580,15 @@ fn show_feature_guidance(feature: &str, enabled: bool) {
                 Output::warning("team_layering requires team_dotfiles to be enabled");
             }
         }
-        "personal_dotfiles" | "personal_packages" => {
-            if config.map(|c| c.backend.url.is_empty()).unwrap_or(true) {
-                println!();
-                Output::info("Set up personal sync repo:");
-                println!("  tether init");
-            }
+        "personal_dotfiles" | "personal_packages"
+            if config
+                .as_ref()
+                .map(|c| c.backend.url.is_empty())
+                .unwrap_or(true) =>
+        {
+            println!();
+            Output::info("Set up personal sync repo:");
+            println!("  tether init");
         }
         _ => {}
     }

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -543,34 +543,31 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
             KeyCode::Char('k') | KeyCode::Up => {
                 picker.cursor = picker.cursor.saturating_sub(1);
             }
-            KeyCode::Enter => {
-                if !picker.items.is_empty() && picker.cursor < picker.items.len() {
-                    let item = picker.items.remove(picker.cursor);
-                    if let (Some(ref mut config), Some(ref ss)) =
-                        (&mut app.state.config, &app.state.sync_state)
-                    {
-                        let ok =
-                            config_edit::add_profile_dotfile(config, &ss.machine_id, &item.path);
-                        if ok {
-                            // Clear from dismissed_imports
-                            if let Ok(mut sync_state) = crate::sync::SyncState::load() {
-                                sync_state.dismissed_imports.remove(&item.path);
-                                let _ = sync_state.save();
-                            }
-                            app.flash_message =
-                                Some((Instant::now(), format!("imported {}", item.path)));
-                            app.reload_state();
-                        } else {
-                            app.flash_error = Some((Instant::now(), "import failed".into()));
+            KeyCode::Enter if !picker.items.is_empty() && picker.cursor < picker.items.len() => {
+                let item = picker.items.remove(picker.cursor);
+                if let (Some(ref mut config), Some(ref ss)) =
+                    (&mut app.state.config, &app.state.sync_state)
+                {
+                    let ok = config_edit::add_profile_dotfile(config, &ss.machine_id, &item.path);
+                    if ok {
+                        // Clear from dismissed_imports
+                        if let Ok(mut sync_state) = crate::sync::SyncState::load() {
+                            sync_state.dismissed_imports.remove(&item.path);
+                            let _ = sync_state.save();
                         }
+                        app.flash_message =
+                            Some((Instant::now(), format!("imported {}", item.path)));
+                        app.reload_state();
+                    } else {
+                        app.flash_error = Some((Instant::now(), "import failed".into()));
                     }
-                    // Clamp cursor
-                    if let Some(ref mut picker) = app.file_import_picker {
-                        if picker.items.is_empty() {
-                            app.file_import_picker = None;
-                        } else if picker.cursor >= picker.items.len() {
-                            picker.cursor = picker.items.len().saturating_sub(1);
-                        }
+                }
+                // Clamp cursor
+                if let Some(ref mut picker) = app.file_import_picker {
+                    if picker.items.is_empty() {
+                        app.file_import_picker = None;
+                    } else if picker.cursor >= picker.items.len() {
+                        picker.cursor = picker.items.len().saturating_sub(1);
                     }
                 }
             }
@@ -624,11 +621,9 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
             KeyCode::Char('k') | KeyCode::Up => {
                 picker.cursor = picker.cursor.saturating_sub(1);
             }
-            KeyCode::Enter => {
-                if !picker.items.is_empty() && picker.cursor < picker.items.len() {
-                    let item = &picker.items[picker.cursor];
-                    app.pkg_install_confirm = Some((item.manager_key.clone(), item.name.clone()));
-                }
+            KeyCode::Enter if !picker.items.is_empty() && picker.cursor < picker.items.len() => {
+                let item = &picker.items[picker.cursor];
+                app.pkg_install_confirm = Some((item.manager_key.clone(), item.name.clone()));
             }
             _ => {}
         }
@@ -764,20 +759,18 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
                     }
                 }
             }
-            KeyCode::Char('t') => {
-                if le.is_dotfile {
-                    let cursor = le.cursor;
-                    let ok = app
-                        .state
-                        .config
-                        .as_mut()
-                        .map(|c| config_edit::toggle_dotfile_create(c, cursor))
-                        .unwrap_or(false);
-                    if !ok {
-                        app.flash_error = Some((Instant::now(), "save failed".into()));
-                    }
-                    refresh_list_edit(app);
+            KeyCode::Char('t') if le.is_dotfile => {
+                let cursor = le.cursor;
+                let ok = app
+                    .state
+                    .config
+                    .as_mut()
+                    .map(|c| config_edit::toggle_dotfile_create(c, cursor))
+                    .unwrap_or(false);
+                if !ok {
+                    app.flash_error = Some((Instant::now(), "save failed".into()));
                 }
+                refresh_list_edit(app);
             }
             _ => {}
         }

--- a/src/dashboard/widgets/config.rs
+++ b/src/dashboard/widgets/config.rs
@@ -79,12 +79,9 @@ pub fn render(
         0
     };
 
-    let mut y = inner_area.y;
-    for (row_idx, row) in rows.iter().enumerate().skip(scroll) {
-        if y >= inner_area.y + inner_area.height {
-            break;
-        }
-
+    for (y, (row_idx, row)) in
+        (inner_area.y..inner_area.y + inner_area.height).zip(rows.iter().enumerate().skip(scroll))
+    {
         let is_selected = field_row_map[row_idx] == Some(selected);
 
         if row.is_header {
@@ -136,7 +133,6 @@ pub fn render(
                 Rect::new(inner_area.x, y, inner_area.width, 1),
             );
         }
-        y += 1;
     }
 }
 
@@ -208,12 +204,9 @@ fn render_list_edit(f: &mut Frame, area: Rect, le: &ListEditState) {
         0
     };
 
-    let mut y = list_start_y;
-    for (i, item) in le.items.iter().enumerate().skip(scroll) {
-        if y >= list_start_y + items_height as u16 {
-            break;
-        }
-
+    for (y, (i, item)) in (list_start_y..list_start_y + items_height as u16)
+        .zip(le.items.iter().enumerate().skip(scroll))
+    {
         let is_selected = i == le.cursor;
         let style = if is_selected {
             Style::default().fg(Color::White).bg(Color::Indexed(240))
@@ -231,7 +224,6 @@ fn render_list_edit(f: &mut Frame, area: Rect, le: &ListEditState) {
             Paragraph::new(line),
             Rect::new(inner_area.x, y, inner_area.width, 1),
         );
-        y += 1;
     }
 
     // Render add input line

--- a/src/dashboard/widgets/files.rs
+++ b/src/dashboard/widgets/files.rs
@@ -365,12 +365,9 @@ pub fn render(f: &mut Frame, area: Rect, state: &DashboardState, ft: &FilesTabSt
         0
     };
 
-    let mut y = inner_area.y;
-    for (row_idx, row) in rows.iter().enumerate().skip(scroll) {
-        if y >= inner_area.y + inner_area.height {
-            break;
-        }
-
+    for (y, (row_idx, row)) in
+        (inner_area.y..inner_area.y + inner_area.height).zip(rows.iter().enumerate().skip(scroll))
+    {
         let is_selected = row_idx == cursor;
         let row_area = Rect::new(inner_area.x, y, inner_area.width, 1);
 
@@ -545,8 +542,6 @@ pub fn render(f: &mut Frame, area: Rect, state: &DashboardState, ft: &FilesTabSt
                 f.render_widget(Paragraph::new(line), row_area);
             }
         }
-
-        y += 1;
     }
 }
 

--- a/src/dashboard/widgets/machines.rs
+++ b/src/dashboard/widgets/machines.rs
@@ -128,12 +128,9 @@ pub fn render(
         0
     };
 
-    let mut y = inner_area.y;
-    for (row_idx, row) in rows.iter().enumerate().skip(scroll) {
-        if y >= inner_area.y + inner_area.height {
-            break;
-        }
-
+    for (y, (row_idx, row)) in
+        (inner_area.y..inner_area.y + inner_area.height).zip(rows.iter().enumerate().skip(scroll))
+    {
         let is_selected = row_idx == cursor;
         let row_area = Rect::new(inner_area.x, y, inner_area.width, 1);
 
@@ -238,8 +235,6 @@ pub fn render(
                 f.render_widget(Paragraph::new(line), row_area);
             }
         }
-
-        y += 1;
     }
 }
 

--- a/src/dashboard/widgets/packages.rs
+++ b/src/dashboard/widgets/packages.rs
@@ -88,12 +88,9 @@ pub fn render(
         0
     };
 
-    let mut y = inner_area.y;
-    for (row_idx, row) in rows.iter().enumerate().skip(scroll) {
-        if y >= inner_area.y + inner_area.height {
-            break;
-        }
-
+    for (y, (row_idx, row)) in
+        (inner_area.y..inner_area.y + inner_area.height).zip(rows.iter().enumerate().skip(scroll))
+    {
         let is_selected = row_idx == cursor;
         let row_area = Rect::new(inner_area.x, y, inner_area.width, 1);
 
@@ -151,8 +148,6 @@ pub fn render(
                 f.render_widget(Paragraph::new(line), row_area);
             }
         }
-
-        y += 1;
     }
 }
 


### PR DESCRIPTION
collapsible_match and explicit_counter_loop now fire on stable, so every PR fails CI until main passes.

- Match guards replace nested ifs; each match already ends in a no-op arm, so fall-through is unchanged.
- Dashboard row loops zip the visible y range instead of a manual counter and break.

No behaviour change. cargo clippy --all-targets -- -D warnings and cargo test --lib pass on 1.98.

https://claude.ai/code/session_01DQwemoce57wvK1b4mvJV6a